### PR TITLE
fix(docs): fixed versions in tutorials/channels.md

### DIFF
--- a/docs/tutorials/channels.md
+++ b/docs/tutorials/channels.md
@@ -318,19 +318,18 @@ tracing = "0.1"
 tokio = "1.42"
 
 [dependencies.malachitebft-app-channel]
-version = "0.1.0"
-git = "ssh://git@github.com/informalsystems/malachite.git"
+version = "0.0.1"
 # This adds the `informalsystems-malachitebft-app-channel` as a dependency, but exposes it
 # under `malachitebft_app_channel` instead of its full package name.
 package = "informalsystems-malachitebft-app-channel"
 
 [dependencies.malachitebft-test]
-version = "0.1.0"
+version = "0.0.1"
 git = "ssh://git@github.com/informalsystems/malachite.git"
 package = "informalsystems-malachitebft-test"
 
 [dependencies.malachitebft-test-cli]
-version = "0.1.0"
+version = "0.0.1"
 git = "ssh://git@github.com/informalsystems/malachite.git"
 package = "informalsystems-malachitebft-test-cli"
 ```


### PR DESCRIPTION
Fixes versions mismatch in [docs/tutorials/channels.md](https://github.com/OakenKnight/malachite/blob/main/docs/tutorials/channels.md)

---

### PR author checklist

#### For all contributors

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
