### PR TITLE
fix(docs): Add git dependencies in tutorial

### DIFF
--- a/docs/tutorials/channels.md
+++ b/docs/tutorials/channels.md
@@ -321,14 +321,17 @@ tokio = "1.42"
 version = "0.0.1"
 # This adds the `informalsystems-malachitebft-app-channel` as a dependency, but exposes it
 # under `malachitebft_app_channel` instead of its full package name.
+git = "ssh://git@github.com/informalsystems/malachite.git"
 package = "informalsystems-malachitebft-app-channel"
 
 [dependencies.malachitebft-test]
 version = "0.0.1"
+git = "ssh://git@github.com/informalsystems/malachite.git"
 package = "informalsystems-malachitebft-test"
 
 [dependencies.malachitebft-test-cli]
 version = "0.0.1"
+git = "ssh://git@github.com/informalsystems/malachite.git"
 package = "informalsystems-malachitebft-test-cli"
 ```
 


### PR DESCRIPTION
This PR resolves the inconsistency in Malachite dependencies in the tutorial. Since `informalsystems-malachitebft-test` is not published on `crates.io`, all related crates are now pulled directly from the Malachite's git repository.

---

### PR author checklist

#### For all contributors

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
