### PR TITLE
feat(code): removed unnecessary `use`

### DIFF
--- a/code/crates/app/src/lib.rs
+++ b/code/crates/app/src/lib.rs
@@ -21,11 +21,6 @@ pub mod streaming {
     pub use malachitebft_engine::util::streaming::*;
 }
 
-pub mod host {
-    // TODO: Move this under `types`
-    pub use malachitebft_engine::host::LocallyProposedValue;
-}
-
 pub mod consensus {
     pub use malachitebft_core_consensus::*;
 }

--- a/code/examples/channel/src/state.rs
+++ b/code/examples/channel/src/state.rs
@@ -10,11 +10,10 @@ use sha3::Digest;
 use tracing::{debug, error};
 
 use malachitebft_app_channel::app::consensus::ProposedValue;
-use malachitebft_app_channel::app::host::LocallyProposedValue;
 use malachitebft_app_channel::app::streaming::{StreamContent, StreamMessage};
 use malachitebft_app_channel::app::types::codec::Codec;
 use malachitebft_app_channel::app::types::core::{CommitCertificate, Round, Validity};
-use malachitebft_app_channel::app::types::PeerId;
+use malachitebft_app_channel::app::types::{LocallyProposedValue, PeerId};
 use malachitebft_test::codec::proto::ProtobufCodec;
 use malachitebft_test::{
     Address, Height, ProposalData, ProposalFin, ProposalInit, ProposalPart, TestContext, Value,


### PR DESCRIPTION
Addresses TODO on [/code/crates/app/src/lib.rs](https://github.com/informalsystems/malachite/tree/9b65e23e7235cad02c007adb988fd9984a5bb5c6/code/crates/app/src/lib.rs#L25). In [types.rs](https://github.com/informalsystems/malachite/blob/9b65e23e7235cad02c007adb988fd9984a5bb5c6/code/crates/app/src/types.rs#L6) there was already `use` for said `struct`, so I removed it.

---

### PR author checklist

#### For all contributors

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
