### PR TITLE
feat(code): Abstract over vote extension type

### DIFF
--- a/code/crates/app-channel/src/msgs.rs
+++ b/code/crates/app-channel/src/msgs.rs
@@ -8,7 +8,7 @@ use tokio::sync::oneshot;
 use malachitebft_engine::consensus::Msg as ConsensusActorMsg;
 use malachitebft_engine::network::Msg as NetworkActorMsg;
 
-use crate::app::types::core::{CommitCertificate, Context, Extension, Round, ValueId};
+use crate::app::types::core::{CommitCertificate, Context, Round, ValueId};
 use crate::app::types::streaming::StreamMessage;
 use crate::app::types::sync::RawDecidedValue;
 use crate::app::types::{LocallyProposedValue, PeerId, ProposedValue};
@@ -65,7 +65,7 @@ pub enum AppMsg<Ctx: Context> {
         height: Ctx::Height,
         round: Round,
         value_id: ValueId<Ctx>,
-        reply: Reply<Option<Extension>>,
+        reply: Reply<Option<Ctx::Extension>>,
     },
 
     /// Requests the application to re-stream a proposal that it has already seen.

--- a/code/crates/core-consensus/src/util/pretty.rs
+++ b/code/crates/core-consensus/src/util/pretty.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use malachitebft_core_types::{Context, NilOrVal, Proposal, Value};
+use malachitebft_core_types::{Context, Extension, NilOrVal, Proposal, Value};
 
 pub struct PrettyVal<'a, T>(pub NilOrVal<&'a T>);
 

--- a/code/crates/core-types/src/context.rs
+++ b/code/crates/core-types/src/context.rs
@@ -1,6 +1,6 @@
 use crate::signing::SigningProvider;
 use crate::{
-    Address, Height, NilOrVal, Proposal, ProposalPart, Round, SigningScheme, Validator,
+    Address, Extension, Height, NilOrVal, Proposal, ProposalPart, Round, SigningScheme, Validator,
     ValidatorSet, Value, ValueId, Vote,
 };
 
@@ -33,6 +33,9 @@ where
 
     /// The type of votes that can be cast.
     type Vote: Vote<Self>;
+
+    /// The type of vote extensions.
+    type Extension: Extension;
 
     /// The signing scheme used to sign consensus messages.
     type SigningScheme: SigningScheme;

--- a/code/crates/core-types/src/lib.rs
+++ b/code/crates/core-types/src/lib.rs
@@ -26,6 +26,7 @@ mod timeout;
 mod validator_set;
 mod value;
 mod vote;
+mod vote_extension;
 mod vote_set;
 
 /// Type alias to make it easier to refer the `ValueId` type.
@@ -50,7 +51,7 @@ pub type SignedProposal<Ctx> = SignedMessage<Ctx, <Ctx as Context>::Proposal>;
 pub type SignedProposalPart<Ctx> = SignedMessage<Ctx, <Ctx as Context>::ProposalPart>;
 
 /// A signed vote extension
-pub type SignedExtension<Ctx> = SignedMessage<Ctx, Extension>;
+pub type SignedExtension<Ctx> = SignedMessage<Ctx, <Ctx as Context>::Extension>;
 
 pub use certificate::{AggregatedSignature, CertificateError, CommitCertificate, CommitSignature};
 pub use context::Context;
@@ -64,5 +65,6 @@ pub use threshold::{Threshold, ThresholdParam, ThresholdParams};
 pub use timeout::{Timeout, TimeoutKind};
 pub use validator_set::{Address, Validator, ValidatorSet, VotingPower};
 pub use value::{NilOrVal, Value, ValueOrigin};
-pub use vote::{Extension, Vote, VoteType};
+pub use vote::{Vote, VoteType};
+pub use vote_extension::Extension;
 pub use vote_set::VoteSet;

--- a/code/crates/core-types/src/signing.rs
+++ b/code/crates/core-types/src/signing.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::fmt::{Debug, Display};
 
 use crate::{
-    CertificateError, CommitCertificate, CommitSignature, Context, Extension, PublicKey, Signature,
+    CertificateError, CommitCertificate, CommitSignature, Context, PublicKey, Signature,
     SignedMessage, ThresholdParams, VotingPower,
 };
 
@@ -87,12 +87,12 @@ where
     ) -> bool;
 
     /// Sign the given vote extension with our private key.
-    fn sign_vote_extension(&self, extension: Extension) -> SignedMessage<Ctx, Extension>;
+    fn sign_vote_extension(&self, extension: Ctx::Extension) -> SignedMessage<Ctx, Ctx::Extension>;
 
     /// Verify the given vote extension's signature using the given public key.
     fn verify_signed_vote_extension(
         &self,
-        extension: &Extension,
+        extension: &Ctx::Extension,
         signature: &Signature<Ctx>,
         public_key: &PublicKey<Ctx>,
     ) -> bool;

--- a/code/crates/core-types/src/vote.rs
+++ b/code/crates/core-types/src/vote.rs
@@ -1,7 +1,5 @@
 use core::fmt::Debug;
 
-use bytes::Bytes;
-
 use crate::{Context, NilOrVal, Round, SignedExtension, Value};
 
 /// A type of vote.
@@ -12,40 +10,6 @@ pub enum VoteType {
 
     /// Votes to commit to a particular value for a given round.
     Precommit,
-}
-
-/// Vote extensions allows applications to extend the pre-commit vote with arbitrary data.
-/// This allows applications to force their validators to do more than just validate blocks within consensus.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Extension {
-    /// This data is opaque to the consensus algorithm but can contain application-specific information.
-    pub data: Bytes,
-}
-
-impl Extension {
-    /// Create a new extension with the given data.
-    pub fn new(data: Bytes) -> Self {
-        Self { data }
-    }
-
-    /// Return the extension data as a byte slice.
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.data
-    }
-
-    /// Get the size of the extension in bytes.
-    pub fn size_bytes(&self) -> usize {
-        self.data.len()
-    }
-}
-
-impl<A> From<A> for Extension
-where
-    A: Into<Bytes>,
-{
-    fn from(data: A) -> Self {
-        Self { data: data.into() }
-    }
 }
 
 /// Defines the requirements for a vote.

--- a/code/crates/core-types/src/vote_extension.rs
+++ b/code/crates/core-types/src/vote_extension.rs
@@ -1,0 +1,38 @@
+use core::fmt::Debug;
+
+use alloc::vec::Vec;
+use bytes::Bytes;
+
+/// Vote extensions allows applications to extend the pre-commit vote with arbitrary data.
+/// This allows applications to force their validators to do more than just validate blocks within consensus.
+pub trait Extension
+where
+    Self: Clone + Debug + Eq + Send + Sync + 'static,
+{
+    /// Returns the size of the extension in bytes.
+    fn size_bytes(&self) -> usize;
+}
+
+impl Extension for () {
+    fn size_bytes(&self) -> usize {
+        0
+    }
+}
+
+impl Extension for Vec<u8> {
+    fn size_bytes(&self) -> usize {
+        self.len()
+    }
+}
+
+impl Extension for Bytes {
+    fn size_bytes(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<const N: usize> Extension for [u8; N] {
+    fn size_bytes(&self) -> usize {
+        N
+    }
+}

--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -11,8 +11,8 @@ use malachitebft_codec as codec;
 use malachitebft_config::TimeoutConfig;
 use malachitebft_core_consensus::{Effect, PeerId, Resumable, Resume, SignedConsensusMsg};
 use malachitebft_core_types::{
-    Context, Extension, Round, SigningProvider, SigningProviderExt, Timeout, TimeoutKind,
-    ValidatorSet, ValueId, ValueOrigin,
+    Context, Round, SigningProvider, SigningProviderExt, Timeout, TimeoutKind, ValidatorSet,
+    ValueId, ValueOrigin,
 };
 use malachitebft_metrics::Metrics;
 use malachitebft_sync::{
@@ -705,7 +705,7 @@ where
         height: Ctx::Height,
         round: Round,
         value_id: ValueId<Ctx>,
-    ) -> Result<Option<Extension>, ActorProcessingErr> {
+    ) -> Result<Option<Ctx::Extension>, ActorProcessingErr> {
         ractor::call!(self.host, |reply_to| HostMsg::ExtendVote {
             height,
             round,

--- a/code/crates/engine/src/host.rs
+++ b/code/crates/engine/src/host.rs
@@ -5,7 +5,7 @@ use derive_where::derive_where;
 use ractor::{ActorRef, RpcReplyPort};
 
 use malachitebft_core_consensus::PeerId;
-use malachitebft_core_types::{CommitCertificate, Context, Extension, Round, ValueId};
+use malachitebft_core_types::{CommitCertificate, Context, Round, ValueId};
 use malachitebft_sync::RawDecidedValue;
 
 use crate::consensus::ConsensusRef;
@@ -42,7 +42,7 @@ pub enum HostMsg<Ctx: Context> {
         height: Ctx::Height,
         round: Round,
         value_id: ValueId<Ctx>,
-        reply_to: RpcReplyPort<Option<Extension>>,
+        reply_to: RpcReplyPort<Option<Ctx::Extension>>,
     },
 
     /// Request to restream an existing block/value from Driver

--- a/code/crates/starknet/host/src/actor.rs
+++ b/code/crates/starknet/host/src/actor.rs
@@ -365,7 +365,7 @@ async fn on_extend_vote(
     height: Height,
     round: Round,
     _value_id: ValueId<MockContext>,
-    reply_to: RpcReplyPort<Option<Extension>>,
+    reply_to: RpcReplyPort<Option<Bytes>>,
 ) -> Result<(), ActorProcessingErr> {
     let extension = state.host.generate_vote_extension(height, round);
     reply_to.send(extension)?;

--- a/code/crates/starknet/host/src/codec.rs
+++ b/code/crates/starknet/host/src/codec.rs
@@ -3,7 +3,7 @@ use prost::Message;
 
 use malachitebft_codec::Codec;
 use malachitebft_core_types::{
-    AggregatedSignature, CommitCertificate, CommitSignature, Extension, Round, SignedExtension,
+    AggregatedSignature, CommitCertificate, CommitSignature, Round, SignedExtension,
     SignedProposal, SignedVote, Validity,
 };
 use malachitebft_engine::util::streaming::{StreamContent, StreamMessage};
@@ -70,20 +70,19 @@ impl Codec<ProposalPart> for ProtobufCodec {
 }
 
 pub fn decode_extension(ext: proto::Extension) -> Result<SignedExtension<MockContext>, ProtoError> {
-    let extension = Extension::from(ext.data);
     let signature = ext
         .signature
         .ok_or_else(|| ProtoError::missing_field::<proto::Extension>("signature"))
         .and_then(p2p::Signature::from_proto)?;
 
-    Ok(SignedExtension::new(extension, signature))
+    Ok(SignedExtension::new(ext.data, signature))
 }
 
 pub fn encode_extension(
     ext: &SignedExtension<MockContext>,
 ) -> Result<proto::Extension, ProtoError> {
     Ok(proto::Extension {
-        data: ext.message.data.clone(),
+        data: ext.message.clone(),
         signature: Some(ext.signature.to_proto()?),
     })
 }

--- a/code/crates/starknet/host/src/host/starknet.rs
+++ b/code/crates/starknet/host/src/host/starknet.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use bytesize::ByteSize;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
@@ -9,7 +10,7 @@ use tracing::{debug, Instrument};
 
 use malachitebft_config::VoteExtensionsConfig;
 use malachitebft_core_consensus::ValuePayload;
-use malachitebft_core_types::{CommitCertificate, Extension, Round, SignedVote};
+use malachitebft_core_types::{CommitCertificate, Round, SignedVote};
 
 use crate::host::Host;
 use crate::mempool::MempoolRef;
@@ -57,7 +58,7 @@ impl StarknetHost {
         }
     }
 
-    pub fn generate_vote_extension(&self, _height: Height, _round: Round) -> Option<Extension> {
+    pub fn generate_vote_extension(&self, _height: Height, _round: Round) -> Option<Bytes> {
         use rand::RngCore;
 
         if !self.params.vote_extensions.enabled {
@@ -70,7 +71,7 @@ impl StarknetHost {
         let mut bytes = vec![0u8; size];
         rand::thread_rng().fill_bytes(&mut bytes);
 
-        Some(Extension::from(bytes))
+        Some(Bytes::from(bytes))
     }
 }
 

--- a/code/crates/starknet/p2p-types/src/context.rs
+++ b/code/crates/starknet/p2p-types/src/context.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use bytes::Bytes;
 use malachitebft_core_types::{Context, NilOrVal, Round, ValidatorSet as _};
 
 use crate::signing::EcdsaProvider;
@@ -32,6 +33,7 @@ impl Context for MockContext {
     type Validator = Validator;
     type Value = BlockHash;
     type Vote = Vote;
+    type Extension = Bytes;
     type SigningScheme = Ecdsa;
     type SigningProvider = EcdsaProvider;
 

--- a/code/crates/starknet/p2p-types/src/signing/provider.rs
+++ b/code/crates/starknet/p2p-types/src/signing/provider.rs
@@ -1,7 +1,8 @@
+use bytes::Bytes;
 use starknet_core::utils::starknet_keccak;
 
 use malachitebft_core_types::{
-    CertificateError, CommitCertificate, CommitSignature, Extension, NilOrVal, SignedExtension,
+    CertificateError, CommitCertificate, CommitSignature, NilOrVal, SignedExtension,
     SignedProposal, SignedProposalPart, SignedVote, SigningProvider, VotingPower,
 };
 
@@ -69,19 +70,19 @@ impl SigningProvider<MockContext> for EcdsaProvider {
         public_key.verify(&hash, signature)
     }
 
-    fn sign_vote_extension(&self, extension: Extension) -> SignedExtension<MockContext> {
-        let hash = starknet_keccak(extension.as_bytes());
+    fn sign_vote_extension(&self, extension: Bytes) -> SignedExtension<MockContext> {
+        let hash = starknet_keccak(extension.as_ref());
         let signature = self.private_key.sign(&hash);
         SignedExtension::new(extension, signature)
     }
 
     fn verify_signed_vote_extension(
         &self,
-        extension: &Extension,
+        extension: &Bytes,
         signature: &Signature,
         public_key: &PublicKey,
     ) -> bool {
-        let hash = starknet_keccak(extension.as_bytes());
+        let hash = starknet_keccak(extension.as_ref());
         public_key.verify(&hash, signature)
     }
 

--- a/code/crates/starknet/p2p-types/src/vote.rs
+++ b/code/crates/starknet/p2p-types/src/vote.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 
-use malachitebft_core_types::{Extension, NilOrVal, Round, SignedExtension, VoteType};
+use malachitebft_core_types::{NilOrVal, Round, SignedExtension, VoteType};
 use malachitebft_proto as proto;
 use malachitebft_starknet_p2p_proto as p2p_proto;
 
@@ -81,13 +81,12 @@ impl proto::Protobuf for Vote {
         let extension = proto
             .extension
             .map(|data| -> Result<_, proto::Error> {
-                let extension = Extension::from(data.data);
                 let signature = data.signature.ok_or_else(|| {
                     proto::Error::missing_field::<Self::Proto>("extension.signature")
                 })?;
 
                 Ok(SignedExtension::new(
-                    extension,
+                    data.data,
                     Signature::from_proto(signature)?,
                 ))
             })
@@ -127,7 +126,7 @@ impl proto::Protobuf for Vote {
                 .as_ref()
                 .map(|ext| -> Result<_, proto::Error> {
                     Ok(p2p_proto::Extension {
-                        data: ext.message.data.clone(),
+                        data: ext.message.clone(),
                         signature: Some(ext.signature.to_proto()?),
                     })
                 })

--- a/code/crates/test/src/codec/proto/mod.rs
+++ b/code/crates/test/src/codec/proto/mod.rs
@@ -5,7 +5,7 @@ use malachitebft_app::streaming::{StreamContent, StreamMessage};
 use malachitebft_codec::Codec;
 use malachitebft_core_consensus::{ProposedValue, SignedConsensusMsg};
 use malachitebft_core_types::{
-    AggregatedSignature, CommitCertificate, CommitSignature, Extension, Round, SignedExtension,
+    AggregatedSignature, CommitCertificate, CommitSignature, Round, SignedExtension,
     SignedProposal, SignedVote, Validity, VoteSet,
 };
 use malachitebft_proto::{Error as ProtoError, Protobuf};
@@ -450,20 +450,19 @@ pub fn encode_aggregate_signature(
 }
 
 pub fn decode_extension(ext: proto::Extension) -> Result<SignedExtension<TestContext>, ProtoError> {
-    let extension = Extension::from(ext.data);
     let signature = ext
         .signature
         .ok_or_else(|| ProtoError::missing_field::<proto::Extension>("signature"))
         .and_then(decode_signature)?;
 
-    Ok(SignedExtension::new(extension, signature))
+    Ok(SignedExtension::new(ext.data, signature))
 }
 
 pub fn encode_extension(
     ext: &SignedExtension<TestContext>,
 ) -> Result<proto::Extension, ProtoError> {
     Ok(proto::Extension {
-        data: ext.message.data.clone(),
+        data: ext.message.clone(),
         signature: Some(encode_signature(&ext.signature)),
     })
 }

--- a/code/crates/test/src/context.rs
+++ b/code/crates/test/src/context.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use bytes::Bytes;
 use malachitebft_core_types::{Context, NilOrVal, Round, ValidatorSet as _};
 
 use crate::address::*;
@@ -33,6 +34,7 @@ impl Context for TestContext {
     type Validator = Validator;
     type Value = Value;
     type Vote = Vote;
+    type Extension = Bytes;
     type SigningScheme = Ed25519;
     type SigningProvider = Ed25519Provider;
 

--- a/code/crates/test/src/signing.rs
+++ b/code/crates/test/src/signing.rs
@@ -1,5 +1,6 @@
+use bytes::Bytes;
 use malachitebft_core_types::{
-    CertificateError, CommitCertificate, CommitSignature, Extension, NilOrVal, SignedExtension,
+    CertificateError, CommitCertificate, CommitSignature, NilOrVal, SignedExtension,
     SignedProposal, SignedProposalPart, SignedVote, SigningProvider, VotingPower,
 };
 
@@ -98,19 +99,19 @@ impl SigningProvider<TestContext> for Ed25519Provider {
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn sign_vote_extension(&self, extension: Extension) -> SignedExtension<TestContext> {
-        let signature = self.private_key.sign(extension.as_bytes());
+    fn sign_vote_extension(&self, extension: Bytes) -> SignedExtension<TestContext> {
+        let signature = self.private_key.sign(extension.as_ref());
         malachitebft_core_types::SignedMessage::new(extension, signature)
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn verify_signed_vote_extension(
         &self,
-        extension: &Extension,
+        extension: &Bytes,
         signature: &Signature,
         public_key: &PublicKey,
     ) -> bool {
-        public_key.verify(extension.as_bytes(), signature).is_ok()
+        public_key.verify(extension.as_ref(), signature).is_ok()
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]


### PR DESCRIPTION
Add the following associated type to the `Context`:

```rust
type Extension: Extension;
```

where `Extension` is defined as

```rust
pub trait Extension
where
    Self: Clone + Debug + Eq + Send + Sync + 'static,
{
    /// Returns the size of the extension in bytes.
    fn size_bytes(&self) -> usize;
}
```

Implementations of `Extension` are provided for the following types:

- `()`
- `Vec<u8>`
- `Bytes`
- `[u8; N]`