### PR TITLE
feat(code/app/starknet): Include existing transactions when reaping the mempool not just the ones generated on the fly

### DIFF
--- a/code/crates/starknet/host/src/mempool.rs
+++ b/code/crates/starknet/host/src/mempool.rs
@@ -217,6 +217,12 @@ impl Actor for Mempool {
             }
 
             Msg::Update { .. } => {
+                // Clear all transactions from the mempool, given that we consume
+                // the full mempool when proposing a block.
+                //
+                // This reduces the mempool protocol overhead and allow us to
+                // observe issues strictly related to consensus.
+                // It also bumps performance, as we reduce the mempool's background traffic.
                 state.transactions.clear();
             }
         }

--- a/code/crates/starknet/host/src/mempool.rs
+++ b/code/crates/starknet/host/src/mempool.rs
@@ -216,8 +216,11 @@ impl Actor for Mempool {
                 reply.send(txes)?;
             }
 
-            Msg::Update { tx_hashes } => {
-                tx_hashes.iter().for_each(|hash| state.remove_tx(hash));
+            Msg::Update { .. } => {
+                // FIXME: Remove only the given txes
+                // tx_hashes.iter().for_each(|hash| state.remove_tx(hash));
+
+                state.transactions.clear();
             }
         }
 

--- a/code/crates/starknet/host/src/mempool.rs
+++ b/code/crates/starknet/host/src/mempool.rs
@@ -216,11 +216,8 @@ impl Actor for Mempool {
                 reply.send(txes)?;
             }
 
-            Msg::Update { .. } => {
-                // FIXME: Remove only the given txes
-                // tx_hashes.iter().for_each(|hash| state.remove_tx(hash));
-
-                state.transactions.clear();
+            Msg::Update { tx_hashes } => {
+                tx_hashes.iter().for_each(|hash| state.remove_tx(hash));
             }
         }
 

--- a/code/crates/starknet/host/src/mempool.rs
+++ b/code/crates/starknet/host/src/mempool.rs
@@ -217,9 +217,6 @@ impl Actor for Mempool {
             }
 
             Msg::Update { .. } => {
-                // FIXME: Remove only the given txes
-                // tx_hashes.iter().for_each(|hash| state.remove_tx(hash));
-
                 state.transactions.clear();
             }
         }

--- a/code/crates/starknet/host/src/mempool.rs
+++ b/code/crates/starknet/host/src/mempool.rs
@@ -256,7 +256,9 @@ fn generate_and_broadcast_txes(
     // Start with transactions already in the mempool
     let mut transactions = std::mem::take(&mut state.transactions)
         .into_values()
+        .take(count)
         .collect::<Vec<_>>();
+
     let initial_count = transactions.len();
 
     let mut tx_batch = Transactions::default();

--- a/code/crates/starknet/host/src/mempool.rs
+++ b/code/crates/starknet/host/src/mempool.rs
@@ -278,14 +278,8 @@ fn generate_and_broadcast_txes(
 
         // Gossip tx-es to peers in batches
         if gossip_enabled && tx_batch.len() >= batch_size {
-            let tx_batch = std::mem::take(&mut tx_batch);
-
-            let Ok(tx_batch_any) = tx_batch.to_any() else {
-                // TODO: Handle error
-                continue;
-            };
-
-            let mempool_batch = MempoolTransactionBatch::new(tx_batch_any);
+            let tx_batch = std::mem::take(&mut tx_batch).to_any().unwrap();
+            let mempool_batch = MempoolTransactionBatch::new(tx_batch);
             mempool_network.cast(MempoolNetworkMsg::BroadcastMsg(mempool_batch))?;
         }
     }


### PR DESCRIPTION
Addresses FIXME on [/code/crates/starknet/host/src/mempool.rs](https://github.com/informalsystems/malachite/blob/1947b34fafbe372e66a45b06c05d13a5f64f6f3a/code/crates/starknet/host/src/mempool.rs#L220)

---

### PR author checklist

#### For all contributors

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
