### PR TITLE
chore(code): Move `SigningProvider` out of `Context`

### DIFF
--- a/code/crates/app-channel/src/run.rs
+++ b/code/crates/app-channel/src/run.rs
@@ -41,7 +41,8 @@ where
     let private_key = node.load_private_key(private_key_file);
     let public_key = node.get_public_key(&private_key);
     let address = node.get_address(&public_key);
-    let keypair = node.get_keypair(private_key);
+    let keypair = node.get_keypair(private_key.clone());
+    let signing_provider = node.get_signing_provider(private_key);
 
     // Spawn consensus gossip
     let (network, network_tx) =
@@ -68,6 +69,7 @@ where
         address,
         ctx,
         cfg,
+        Box::new(signing_provider),
         network,
         connector,
         wal,

--- a/code/crates/app/src/node.rs
+++ b/code/crates/app/src/node.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
+use malachitebft_core_types::SigningProvider;
 use rand::{CryptoRng, RngCore};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -14,6 +15,7 @@ pub trait Node {
     type Context: Context;
     type Genesis: Serialize + DeserializeOwned;
     type PrivateKeyFile: Serialize + DeserializeOwned;
+    type SigningProvider: SigningProvider<Self::Context>;
 
     fn get_home_dir(&self) -> PathBuf;
 
@@ -33,6 +35,9 @@ pub trait Node {
 
     fn make_private_key_file(&self, private_key: PrivateKey<Self::Context>)
         -> Self::PrivateKeyFile;
+
+    fn get_signing_provider(&self, private_key: PrivateKey<Self::Context>)
+        -> Self::SigningProvider;
 
     fn load_genesis(&self, path: impl AsRef<Path>) -> io::Result<Self::Genesis>;
 

--- a/code/crates/app/src/spawn.rs
+++ b/code/crates/app/src/spawn.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use eyre::Result;
+use malachitebft_core_types::SigningProvider;
 use tracing::Span;
 
 use malachitebft_engine::consensus::{Consensus, ConsensusCodec, ConsensusParams, ConsensusRef};
@@ -45,6 +46,7 @@ pub async fn spawn_consensus_actor<Ctx>(
     address: Ctx::Address,
     ctx: Ctx,
     cfg: NodeConfig,
+    signing_provider: Box<dyn SigningProvider<Ctx>>,
     network: NetworkRef<Ctx>,
     host: HostRef<Ctx>,
     wal: WalRef<Ctx>,
@@ -56,6 +58,7 @@ where
     Ctx: Context,
 {
     use crate::types::config;
+
     let value_payload = match cfg.consensus.value_payload {
         config::ValuePayload::PartsOnly => ValuePayload::PartsOnly,
         config::ValuePayload::ProposalOnly => ValuePayload::ProposalOnly,
@@ -74,6 +77,7 @@ where
         ctx,
         consensus_params,
         cfg.consensus.timeouts,
+        signing_provider,
         network,
         host,
         wal,

--- a/code/crates/core-consensus/tests/full_proposal.rs
+++ b/code/crates/core-consensus/tests/full_proposal.rs
@@ -1,8 +1,6 @@
-use malachitebft_core_types::{
-    Context, Round, SignedProposal, SigningProvider, Validity, ValueOrigin,
-};
+use malachitebft_core_types::{Round, SignedProposal, SigningProvider, Validity, ValueOrigin};
 use malachitebft_test::utils::validators::make_validators;
-use malachitebft_test::{Address, Proposal, Value};
+use malachitebft_test::{Address, Ed25519Provider, Proposal, Value};
 use malachitebft_test::{Height, TestContext};
 
 use informalsystems_malachitebft_core_consensus::{
@@ -10,7 +8,7 @@ use informalsystems_malachitebft_core_consensus::{
 };
 
 fn signed_proposal_pol(
-    ctx: &TestContext,
+    signing_provider: &Ed25519Provider,
     height: Height,
     round: Round,
     value: Value,
@@ -18,18 +16,18 @@ fn signed_proposal_pol(
     address: Address,
 ) -> SignedProposal<TestContext> {
     let proposal1 = Proposal::new(height, round, value, pol_round, address);
-    ctx.signing_provider().sign_proposal(proposal1)
+    signing_provider.sign_proposal(proposal1)
 }
 
 fn prop(
-    ctx: &TestContext,
+    signing_provider: &Ed25519Provider,
     address: Address,
     round: u32,
     value: u64,
     pol_round: i64,
 ) -> SignedProposal<TestContext> {
     signed_proposal_pol(
-        ctx,
+        signing_provider,
         Height::new(1),
         Round::new(round),
         Value::new(value),
@@ -39,13 +37,13 @@ fn prop(
 }
 
 fn prop_msg(
-    ctx: &TestContext,
+    signing_provider: &Ed25519Provider,
     address: Address,
     round: u32,
     value: u64,
     pol_round: i64,
 ) -> Input<TestContext> {
-    Input::Proposal(prop(ctx, address, round, value, pol_round))
+    Input::Proposal(prop(signing_provider, address, round, value, pol_round))
 }
 
 fn value(
@@ -111,10 +109,12 @@ struct Test {
 #[test]
 fn full_proposal_keeper_tests() {
     let [(v1, sk1), (v2, sk2)] = make_validators([1, 1]);
+
     let a1 = v1.address;
-    let c1 = TestContext::new(sk1);
     let a2 = v2.address;
-    let c2 = TestContext::new(sk2);
+
+    let c1 = Ed25519Provider::new(sk1);
+    let c2 = Ed25519Provider::new(sk2);
 
     let tests = vec![
         Test {

--- a/code/crates/core-driver/tests/it/basic.rs
+++ b/code/crates/core-driver/tests/it/basic.rs
@@ -86,10 +86,10 @@ fn driver_steps_proposer() {
     let value = Value::new(9999);
 
     let [(v1, sk1), (v2, _sk2), (v3, _sk3)] = make_validators([1, 2, 3]);
-    let (my_sk, my_addr) = (sk1, v1.address);
+    let (_my_sk, my_addr) = (sk1, v1.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let sel = Arc::new(FixedProposer::new(my_addr));
     let vs = ValidatorSet::new(vec![v1, v2.clone(), v3.clone()]);
 
@@ -290,10 +290,10 @@ fn driver_steps_proposer() {
 #[test]
 fn driver_steps_proposer_timeout_get_value() {
     let [(v1, sk1), (v2, _sk2), (v3, _sk3)] = make_validators([1, 2, 3]);
-    let (my_sk, my_addr) = (sk1, v1.address);
+    let (_my_sk, my_addr) = (sk1, v1.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let sel = Arc::new(FixedProposer::new(my_addr));
     let vs = ValidatorSet::new(vec![v1, v2.clone(), v3.clone()]);
 
@@ -348,10 +348,10 @@ fn driver_steps_not_proposer_valid() {
     let [(v1, _sk1), (v2, sk2), (v3, _sk3)] = make_validators([1, 2, 3]);
 
     // Proposer is v1, so we are not the proposer
-    let (my_sk, my_addr) = (sk2, v2.address);
+    let (_my_sk, my_addr) = (sk2, v2.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let sel = Arc::new(FixedProposer::new(v1.address));
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
@@ -541,10 +541,10 @@ fn driver_steps_not_proposer_invalid() {
     let [(v1, _sk1), (v2, sk2), (v3, _sk3)] = make_validators([1, 2, 3]);
 
     // Proposer is v1, so we are not the proposer
-    let (my_sk, my_addr) = (sk2, v2.address);
+    let (_my_sk, my_addr) = (sk2, v2.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let sel = Arc::new(FixedProposer::new(v1.address));
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
@@ -668,10 +668,10 @@ fn driver_steps_not_proposer_other_height() {
     let [(v1, _sk1), (v2, sk2)] = make_validators([1, 2]);
 
     // Proposer is v1, so we are not the proposer
-    let (my_sk, my_addr) = (sk2, v2.address);
+    let (_my_sk, my_addr) = (sk2, v2.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let sel = Arc::new(FixedProposer::new(v1.address));
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone()]);
 
@@ -732,10 +732,10 @@ fn driver_steps_not_proposer_other_round() {
     let [(v1, _sk1), (v2, sk2)] = make_validators([1, 2]);
 
     // Proposer is v1, so we are not the proposer
-    let (my_sk, my_addr) = (sk2, v2.address);
+    let (_my_sk, my_addr) = (sk2, v2.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let sel = Arc::new(FixedProposer::new(v1.address));
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone()]);
 
@@ -787,10 +787,10 @@ fn driver_steps_not_proposer_timeout_multiple_rounds() {
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([1, 3, 1]);
 
     // Proposer is v1, so we, v3, are not the proposer
-    let (my_sk, my_addr) = (sk3, v3.address);
+    let (_my_sk, my_addr) = (sk3, v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let sel = Arc::new(FixedProposer::new(v1.address));
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
@@ -965,10 +965,10 @@ fn driver_steps_not_proposer_timeout_multiple_rounds() {
 #[test]
 fn driver_steps_no_value_to_propose() {
     let [(v1, sk1), (v2, _sk2), (v3, _sk3)] = make_validators([1, 2, 3]);
-    let (my_sk, my_addr) = (sk1, v1.address);
+    let (_my_sk, my_addr) = (sk1, v1.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
 
     // We are the proposer
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
@@ -996,10 +996,10 @@ fn driver_steps_no_value_to_propose() {
 fn driver_steps_proposer_not_found() {
     let [(v1, _sk1), (v2, sk2), (v3, _sk3)] = make_validators([1, 2, 3]);
 
-    let (my_sk, my_addr) = (sk2, v2.address);
+    let (_my_sk, my_addr) = (sk2, v2.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
 
     // Proposer is v1, which is not in the validator set
     let vs = ValidatorSet::new(vec![v2.clone(), v3.clone()]);
@@ -1016,10 +1016,10 @@ fn driver_steps_validator_not_found() {
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([1, 2, 3]);
 
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
 
     // Proposer is v1
     // We omit v2 from the validator set
@@ -1052,9 +1052,9 @@ fn driver_steps_skip_round_skip_threshold() {
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([1, 1, 1]);
 
     // Proposer is v1, so we, v3, are not the proposer
-    let (my_sk, my_addr) = (sk3, v3.address);
+    let (_my_sk, my_addr) = (sk3, v3.address);
 
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let height = Height::new(1);
 
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
@@ -1154,10 +1154,10 @@ fn driver_steps_skip_round_quorum_threshold() {
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([1, 2, 1]);
 
     // Proposer is v1, so we, v3, are not the proposer
-    let (my_sk, my_addr) = (sk3, v3.address);
+    let (_my_sk, my_addr) = (sk3, v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
 
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
     let mut driver = Driver::new(ctx, height, vs.clone(), my_addr, Default::default());

--- a/code/crates/core-driver/tests/it/extra.rs
+++ b/code/crates/core-driver/tests/it/extra.rs
@@ -64,10 +64,10 @@ fn driver_steps_decide_current_with_no_locked_no_valid() {
     let value = Value::new(9999);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let proposal = Proposal::new(
@@ -146,10 +146,10 @@ fn driver_steps_decide_previous_with_no_locked_no_valid() {
     let value = Value::new(9999);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let mut driver = Driver::new(ctx, height, vs, my_addr, Default::default());
@@ -263,10 +263,10 @@ fn driver_steps_decide_previous_with_locked_and_valid() {
     let value = Value::new(9999);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let mut driver = Driver::new(ctx, height, vs, my_addr, Default::default());
@@ -401,10 +401,10 @@ fn driver_steps_polka_previous_with_locked() {
     let value = Value::new(9999);
 
     let [(v1, _sk1), (v2, sk2), (v3, _sk3)] = make_validators([2, 2, 3]);
-    let (my_sk, my_addr) = (sk2, v2.address);
+    let (_my_sk, my_addr) = (sk2, v2.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let mut driver = Driver::new(ctx, height, vs, my_addr, Default::default());
@@ -549,10 +549,10 @@ fn driver_steps_polka_previous_invalid_proposal() {
     let value = Value::new(9999);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3, v3.address);
+    let (_my_sk, my_addr) = (sk3, v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let mut driver = Driver::new(ctx, height, vs, my_addr, Default::default());
@@ -645,10 +645,10 @@ fn driver_steps_polka_previous_new_proposal() {
     let other_value = Value::new(8888);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3, v3.address);
+    let (_my_sk, my_addr) = (sk3, v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let mut driver = Driver::new(ctx, height, vs, my_addr, Default::default());
@@ -791,10 +791,10 @@ fn driver_steps_polka_previous_with_no_locked() {
     let value = Value::new(9999);
 
     let [(v1, _sk1), (v2, sk2), (v3, _sk3)] = make_validators([2, 2, 3]);
-    let (my_sk, my_addr) = (sk2, v2.address);
+    let (_my_sk, my_addr) = (sk2, v2.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let mut driver = Driver::new(ctx, height, vs, my_addr, Default::default());
@@ -916,10 +916,10 @@ fn driver_steps_polka_previous_with_no_locked() {
 #[test]
 fn driver_steps_polka_nil_and_timeout_propose() {
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let mut driver = Driver::new(ctx, height, vs, my_addr, Default::default());
@@ -979,10 +979,10 @@ fn driver_steps_polka_value_then_proposal() {
     let value = Value::new(9999);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let mut driver = Driver::new(ctx, height, vs, my_addr, Default::default());
@@ -1057,10 +1057,10 @@ fn driver_steps_polka_any_then_proposal_other() {
     let value = Value::new(9999);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let mut driver = Driver::new(ctx, height, vs, my_addr, Default::default());
@@ -1108,10 +1108,10 @@ fn driver_equivocate_vote() {
     let value2 = Value::new(42);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let proposal = Proposal::new(
@@ -1177,10 +1177,10 @@ fn driver_equivocate_proposal() {
     let value2 = Value::new(42);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let proposal = Proposal::new(
@@ -1256,10 +1256,10 @@ fn driver_conflicting_proposal_unreachable() {
     let value2 = Value::new(42);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let mut driver = Driver::new(ctx, height, vs, my_addr, Default::default());
@@ -1308,10 +1308,10 @@ fn driver_step_change_mux_with_proposal() {
     let value: Value = Value::new(9999);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let mut driver = Driver::new(ctx, height, vs, my_addr, Default::default());
@@ -1403,10 +1403,10 @@ fn driver_step_change_mux_with_proposal_and_polka() {
     let value: Value = Value::new(9999);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let proposal = Proposal::new(
@@ -1480,10 +1480,10 @@ fn driver_step_change_mux_with_proposal_and_commit_quorum() {
     let value: Value = Value::new(9999);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let proposal = Proposal::new(
@@ -1552,10 +1552,10 @@ fn proposal_mux_with_polka() {
     let value: Value = Value::new(9999);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let proposal = Proposal::new(
@@ -1626,10 +1626,10 @@ fn proposal_mux_with_commit_quorum() {
     let value: Value = Value::new(9999);
 
     let [(v1, _sk1), (v2, _sk2), (v3, sk3)] = make_validators([2, 3, 2]);
-    let (my_sk, my_addr) = (sk3.clone(), v3.address);
+    let (_my_sk, my_addr) = (sk3.clone(), v3.address);
 
     let height = Height::new(1);
-    let ctx = TestContext::new(my_sk.clone());
+    let ctx = TestContext::new();
     let vs = ValidatorSet::new(vec![v1.clone(), v2.clone(), v3.clone()]);
 
     let proposal = Proposal::new(

--- a/code/crates/core-types/src/context.rs
+++ b/code/crates/core-types/src/context.rs
@@ -1,4 +1,3 @@
-use crate::signing::SigningProvider;
 use crate::{
     Address, Height, NilOrVal, Proposal, ProposalPart, Round, SigningScheme, Validator,
     ValidatorSet, Value, ValueId, Vote,
@@ -38,9 +37,6 @@ where
     /// The signing scheme used to sign consensus messages.
     type SigningScheme: SigningScheme;
 
-    /// The signing provider used to sign and verify consensus messages.
-    type SigningProvider: SigningProvider<Self>;
-
     /// Select a proposer in the validator set for the given height and round.
     fn select_proposer<'a>(
         &self,
@@ -48,9 +44,6 @@ where
         height: Self::Height,
         round: Round,
     ) -> &'a Self::Validator;
-
-    /// Get the singing provider.
-    fn signing_provider(&self) -> &Self::SigningProvider;
 
     /// Build a new proposal for the given value at the given height, round and POL round.
     fn new_proposal(

--- a/code/crates/starknet/host/src/node.rs
+++ b/code/crates/starknet/host/src/node.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use libp2p_identity::ecdsa;
+use malachitebft_starknet_p2p_types::EcdsaProvider;
 use ractor::async_trait;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -55,6 +56,7 @@ impl Node for StarknetNode {
     type Context = MockContext;
     type Genesis = Genesis;
     type PrivateKeyFile = PrivateKeyFile;
+    type SigningProvider = EcdsaProvider;
 
     fn get_home_dir(&self) -> PathBuf {
         self.home_dir.to_owned()
@@ -96,6 +98,10 @@ impl Node for StarknetNode {
 
     fn make_private_key_file(&self, private_key: PrivateKey) -> Self::PrivateKeyFile {
         PrivateKeyFile::from(private_key)
+    }
+
+    fn get_signing_provider(&self, private_key: PrivateKey) -> Self::SigningProvider {
+        EcdsaProvider::new(private_key)
     }
 
     fn load_genesis(&self, path: impl AsRef<Path>) -> std::io::Result<Self::Genesis> {

--- a/code/crates/starknet/p2p-types/src/context.rs
+++ b/code/crates/starknet/p2p-types/src/context.rs
@@ -1,25 +1,17 @@
-use std::sync::Arc;
-
 use malachitebft_core_types::{Context, NilOrVal, Round, ValidatorSet as _};
 
-use crate::signing::EcdsaProvider;
 use crate::{
-    Address, BlockHash, Ecdsa, Height, PrivateKey, Proposal, ProposalPart, Validator, ValidatorSet,
-    Vote,
+    Address, BlockHash, Ecdsa, Height, Proposal, ProposalPart, Validator, ValidatorSet, Vote,
 };
 
 mod impls;
 
-#[derive(Clone, Debug)]
-pub struct MockContext {
-    ecdsa_provider: Arc<EcdsaProvider>,
-}
+#[derive(Copy, Clone, Debug, Default)]
+pub struct MockContext;
 
 impl MockContext {
-    pub fn new(private_key: PrivateKey) -> Self {
-        Self {
-            ecdsa_provider: Arc::new(EcdsaProvider::new(private_key)),
-        }
+    pub fn new() -> Self {
+        Self
     }
 }
 
@@ -33,11 +25,6 @@ impl Context for MockContext {
     type Value = BlockHash;
     type Vote = Vote;
     type SigningScheme = Ecdsa;
-    type SigningProvider = EcdsaProvider;
-
-    fn signing_provider(&self) -> &Self::SigningProvider {
-        &self.ecdsa_provider
-    }
 
     fn select_proposer<'a>(
         &self,

--- a/code/crates/test/src/context.rs
+++ b/code/crates/test/src/context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use malachitebft_core_types::{Context, NilOrVal, Round, ValidatorSet as _};
 
 use crate::address::*;
@@ -11,16 +9,12 @@ use crate::validator_set::*;
 use crate::value::*;
 use crate::vote::*;
 
-#[derive(Clone, Debug)]
-pub struct TestContext {
-    pub signing_provider: Arc<Ed25519Provider>,
-}
+#[derive(Copy, Clone, Debug, Default)]
+pub struct TestContext;
 
 impl TestContext {
-    pub fn new(private_key: PrivateKey) -> Self {
-        Self {
-            signing_provider: Arc::new(Ed25519Provider::new(private_key)),
-        }
+    pub fn new() -> Self {
+        Self
     }
 }
 
@@ -34,11 +28,6 @@ impl Context for TestContext {
     type Value = Value;
     type Vote = Vote;
     type SigningScheme = Ed25519;
-    type SigningProvider = Ed25519Provider;
-
-    fn signing_provider(&self) -> &Self::SigningProvider {
-        &self.signing_provider
-    }
 
     fn select_proposer<'a>(
         &self,

--- a/code/crates/test/src/node.rs
+++ b/code/crates/test/src/node.rs
@@ -9,7 +9,7 @@ use malachitebft_config::Config;
 use malachitebft_core_types::VotingPower;
 
 use crate::context::TestContext;
-use crate::{Address, Genesis, PrivateKey, PublicKey, Validator, ValidatorSet};
+use crate::{Address, Ed25519Provider, Genesis, PrivateKey, PublicKey, Validator, ValidatorSet};
 
 pub struct TestNode {
     pub config: Config,
@@ -24,6 +24,7 @@ impl Node for TestNode {
     type Context = TestContext;
     type Genesis = Genesis;
     type PrivateKeyFile = PrivateKey;
+    type SigningProvider = Ed25519Provider;
 
     fn get_home_dir(&self) -> PathBuf {
         self.home_dir.to_owned()
@@ -62,6 +63,10 @@ impl Node for TestNode {
 
     fn make_private_key_file(&self, private_key: PrivateKey) -> Self::PrivateKeyFile {
         private_key
+    }
+
+    fn get_signing_provider(&self, private_key: PrivateKey) -> Self::SigningProvider {
+        Ed25519Provider::new(private_key)
     }
 
     fn load_genesis(&self, path: impl AsRef<Path>) -> std::io::Result<Self::Genesis> {


### PR DESCRIPTION
The `Context` should not concern itself with signing as the core consensus library does not sign nor verify signatures itself, but rather does so via effects.

The `SigningProvider` trait is still used in the `engine` crate for signing messages and verifying signatures, but should eventually be removed in favor of `HostMsg` pertaining to verification.