### PR TITLE
fix(code/core-consensus): Verify vote extension on precommits

### DIFF
--- a/code/crates/core-consensus/src/handle/vote.rs
+++ b/code/crates/core-consensus/src/handle/vote.rs
@@ -107,12 +107,14 @@ where
 {
     let consensus_height = state.driver.height();
     let vote_height = signed_vote.height();
+    let vote_round = signed_vote.round();
     let validator_address = signed_vote.validator_address();
 
     let Some(validator_set) = get_validator_set(co, state, signed_vote.height()).await? else {
         debug!(
             consensus.height = %consensus_height,
             vote.height = %vote_height,
+            vote.round = %vote_round,
             validator = %validator_address,
             "Received vote for height without known validator set, dropping"
         );
@@ -124,6 +126,7 @@ where
         warn!(
             consensus.height = %consensus_height,
             vote.height = %vote_height,
+            vote.round = %vote_round,
             validator = %validator_address,
             "Received vote from unknown validator"
         );
@@ -136,8 +139,59 @@ where
         warn!(
             consensus.height = %consensus_height,
             vote.height = %vote_height,
+            vote.round = %vote_round,
             validator = %validator_address,
             "Received vote with invalid signature: {}", PrettyVote::<Ctx>(&signed_vote.message)
+        );
+
+        return Ok(false);
+    }
+
+    verify_vote_extension(co, state, signed_vote, validator).await
+}
+
+async fn verify_vote_extension<Ctx>(
+    co: &Co<Ctx>,
+    state: &State<Ctx>,
+    vote: &SignedVote<Ctx>,
+    validator: &Ctx::Validator,
+) -> Result<bool, Error<Ctx>>
+where
+    Ctx: Context,
+{
+    let VoteType::Precommit = vote.vote_type() else {
+        return Ok(true);
+    };
+
+    let NilOrVal::Val(value_id) = vote.value().as_ref() else {
+        return Ok(true);
+    };
+
+    let Some(extension) = vote.extension() else {
+        return Ok(true);
+    };
+
+    let result = perform!(
+        co,
+        Effect::VerifyVoteExtension(
+            vote.height(),
+            vote.round(),
+            value_id.clone(),
+            extension.clone(),
+            validator.public_key().clone(),
+            Default::default()
+        ),
+        Resume::VoteExtensionValidity(result) => result
+    );
+
+    if let Err(e) = result {
+        warn!(
+            consensus.height = %state.driver.height(),
+            vote.height = %vote.height(),
+            vote.round = %vote.round(),
+            validator = %validator.address(),
+            "Received vote with invalid extension: {}, reason: {e}",
+            PrettyVote::<Ctx>(&vote.message)
         );
 
         return Ok(false);

--- a/code/crates/core-consensus/src/types.rs
+++ b/code/crates/core-consensus/src/types.rs
@@ -1,4 +1,5 @@
 use derive_where::derive_where;
+use thiserror::Error;
 
 use malachitebft_core_types::{
     Context, Proposal, Round, Signature, SignedProposal, SignedVote, Validity, Vote,
@@ -69,8 +70,10 @@ pub struct ProposedValue<Ctx: Context> {
     pub validity: Validity,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
 pub enum VoteExtensionError {
+    #[error("Invalid vote extension signature")]
     InvalidSignature,
+    #[error("Invalid vote extension")]
     InvalidVoteExtension,
 }


### PR DESCRIPTION
Closes: #XXX

## Questions

- [ ] Should we enforce that prevotes do not have any extensions?
- [ ] Should we enforce that precommits may only have an extension if they are for a non-nil value?

---

### PR author checklist

#### For all contributors

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
