### PR TITLE
chore(code): Some WAL entries fail to decode

### DIFF
--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -599,12 +599,14 @@ where
                 state.phase = Phase::Recovering;
 
                 if let Err(e) = self.replay_wal_entries(myself, state, entries).await {
+                    self.tx_event.send(|| Event::WalReplayError);
                     error!(%height, "Failed to replay WAL entries: {e}");
                 }
 
                 state.phase = Phase::Running;
             }
             Err(e) => {
+                self.tx_event.send(|| Event::WalReplayError);
                 error!(%height, "Error when notifying WAL of started height: {e}")
             }
         }

--- a/code/crates/engine/src/util/events.rs
+++ b/code/crates/engine/src/util/events.rs
@@ -49,6 +49,7 @@ pub enum Event<Ctx: Context> {
     WalReplayConsensus(SignedConsensusMsg<Ctx>),
     WalReplayTimeout(Timeout),
     WalReplayDone(Ctx::Height),
+    WalReplayError,
 }
 
 impl<Ctx: Context> fmt::Display for Event<Ctx> {
@@ -82,6 +83,7 @@ impl<Ctx: Context> fmt::Display for Event<Ctx> {
             Event::WalReplayConsensus(msg) => write!(f, "WalReplayConsensus(msg: {msg:?})"),
             Event::WalReplayTimeout(timeout) => write!(f, "WalReplayTimeout(timeout: {timeout:?})"),
             Event::WalReplayDone(height) => write!(f, "WalReplayDone(height: {height})"),
+            Event::WalReplayError => write!(f, "WalReplayError"), // TODO: add error message
         }
     }
 }

--- a/code/crates/engine/src/util/events.rs
+++ b/code/crates/engine/src/util/events.rs
@@ -1,6 +1,8 @@
 use core::fmt;
+use std::sync::Arc;
 
 use derive_where::derive_where;
+use ractor::ActorProcessingErr;
 use tokio::sync::broadcast;
 
 use malachitebft_core_consensus::{LocallyProposedValue, ProposedValue, SignedConsensusMsg};
@@ -49,7 +51,7 @@ pub enum Event<Ctx: Context> {
     WalReplayConsensus(SignedConsensusMsg<Ctx>),
     WalReplayTimeout(Timeout),
     WalReplayDone(Ctx::Height),
-    WalReplayError,
+    WalReplayError(Arc<ActorProcessingErr>),
 }
 
 impl<Ctx: Context> fmt::Display for Event<Ctx> {
@@ -83,7 +85,7 @@ impl<Ctx: Context> fmt::Display for Event<Ctx> {
             Event::WalReplayConsensus(msg) => write!(f, "WalReplayConsensus(msg: {msg:?})"),
             Event::WalReplayTimeout(timeout) => write!(f, "WalReplayTimeout(timeout: {timeout:?})"),
             Event::WalReplayDone(height) => write!(f, "WalReplayDone(height: {height})"),
-            Event::WalReplayError => write!(f, "WalReplayError"), // TODO: add error message
+            Event::WalReplayError(error) => write!(f, "WalReplayError({error})"),
         }
     }
 }

--- a/code/crates/engine/src/wal/entry.rs
+++ b/code/crates/engine/src/wal/entry.rs
@@ -60,15 +60,15 @@ where
     {
         match self {
             WalEntry::ConsensusMsg(msg) => {
-                // Write tag
-                buf.write_u8(Self::TAG_CONSENSUS)?;
-
                 let bytes = codec.encode(msg).map_err(|e| {
                     io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!("failed to encode consensus message: {e}"),
                     )
                 })?;
+
+                // Write tag
+                buf.write_u8(Self::TAG_CONSENSUS)?;
 
                 // Write encoded length
                 buf.write_u64::<BE>(bytes.len() as u64)?;

--- a/code/crates/engine/src/wal/entry.rs
+++ b/code/crates/engine/src/wal/entry.rs
@@ -80,11 +80,8 @@ where
             }
 
             WalEntry::Timeout(timeout) => {
-                // Write tag
-                buf.write_u8(Self::TAG_TIMEOUT)?;
-
-                // Write timeout
-                encode_timeout(timeout, &mut buf)?;
+                // Write tag and timeout if applicable
+                encode_timeout(Self::TAG_TIMEOUT, timeout, &mut buf)?;
 
                 Ok(())
             }
@@ -124,7 +121,7 @@ where
     }
 }
 
-fn encode_timeout(timeout: &Timeout, mut buf: impl Write) -> io::Result<()> {
+fn encode_timeout(tag: u8, timeout: &Timeout, mut buf: impl Write) -> io::Result<()> {
     use malachitebft_core_types::TimeoutKind;
 
     let step = match timeout.kind {
@@ -138,6 +135,7 @@ fn encode_timeout(timeout: &Timeout, mut buf: impl Write) -> io::Result<()> {
     };
 
     if step > 0 {
+        buf.write_u8(tag)?;
         buf.write_u8(step)?;
         buf.write_i64::<BE>(timeout.round.as_i64())?;
     }

--- a/code/crates/engine/src/wal/thread.rs
+++ b/code/crates/engine/src/wal/thread.rs
@@ -97,7 +97,7 @@ where
                     error!("ATTENTION: Failed to append entry to WAL: {e}");
                 } else {
                     debug!(
-                        type = %tpe, entry.size = %buf.len(), length = %log.len(),
+                        type = %tpe, entry.size = %buf.len(), log.entries = %log.len(),
                         "Wrote log entry"
                     );
                 }
@@ -115,8 +115,8 @@ where
                 error!("ATTENTION: Failed to flush WAL to disk: {e}");
             } else {
                 debug!(
-                    log.entries = %log.len(),
-                    log.size = %log.size_bytes().unwrap_or(0),
+                    wal.entries = %log.len(),
+                    wal.size = %log.size_bytes().unwrap_or(0),
                     "Flushed WAL to disk"
                 );
             }

--- a/code/crates/engine/src/wal/thread.rs
+++ b/code/crates/engine/src/wal/thread.rs
@@ -166,7 +166,11 @@ where
         .collect::<Vec<_>>();
 
     if log.len() != entries.len() {
-        Err(eyre::eyre!("Failed to fetch and decode all WAL entries"))
+        Err(eyre::eyre!(
+            "Failed to fetch and decode all WAL entries: expected {}, got {}",
+            log.len(),
+            entries.len()
+        ))
     } else {
         Ok(entries)
     }

--- a/code/crates/engine/src/wal/thread.rs
+++ b/code/crates/engine/src/wal/thread.rs
@@ -91,20 +91,22 @@ where
             let mut buf = Vec::new();
             entry.encode(codec, &mut buf)?;
 
-            let result = log.append(&buf).map_err(Into::into);
+            if !buf.is_empty() {
+                let result = log.append(&buf).map_err(Into::into);
 
-            if let Err(e) = &result {
-                error!("ATTENTION: Failed to append entry to WAL: {e}");
-            } else {
-                let length = log.len();
-                debug!(
-                    type = %tpe, entry.size = %buf.len(), length,
-                    "Wrote log entry"
-                );
-            }
+                if let Err(e) = &result {
+                    error!("ATTENTION: Failed to append entry to WAL: {e}");
+                } else {
+                    let length = log.len();
+                    debug!(
+                        type = %tpe, entry.size = %buf.len(), length,
+                        "Wrote log entry"
+                    );
+                }
 
-            if reply.send(result).is_err() {
-                error!("Failed to send WAL append reply");
+                if reply.send(result).is_err() {
+                    error!("Failed to send WAL append reply");
+                }
             }
         }
 

--- a/code/crates/engine/src/wal/thread.rs
+++ b/code/crates/engine/src/wal/thread.rs
@@ -165,5 +165,9 @@ where
         )
         .collect::<Vec<_>>();
 
-    Ok(entries)
+    if log.len() != entries.len() {
+        Err(eyre::eyre!("Failed to fetch and decode all WAL entries"))
+    } else {
+        Ok(entries)
+    }
 }

--- a/code/crates/engine/src/wal/thread.rs
+++ b/code/crates/engine/src/wal/thread.rs
@@ -61,7 +61,6 @@ where
             let sequence = height.as_u64();
 
             if sequence == log.sequence() {
-                info!("Wal has {} entries", log.len());
                 // WAL is already at that sequence
                 // Let's check if there are any entries to replay
                 let entries = fetch_entries(log, codec);
@@ -97,9 +96,8 @@ where
                 if let Err(e) = &result {
                     error!("ATTENTION: Failed to append entry to WAL: {e}");
                 } else {
-                    let length = log.len();
                     debug!(
-                        type = %tpe, entry.size = %buf.len(), length,
+                        type = %tpe, entry.size = %buf.len(), length = %log.len(),
                         "Wrote log entry"
                     );
                 }

--- a/code/crates/starknet/test/src/lib.rs
+++ b/code/crates/starknet/test/src/lib.rs
@@ -512,6 +512,9 @@ async fn run_node<S>(
                         Event::Published(msg) if is_full_node => {
                             panic!("Full nodes unexpectedly publish a consensus message: {msg:?}");
                         }
+                        Event::WalReplayError(e) => {
+                            panic!("WAL replay error: {e}");
+                        }
                         _ => (),
                     }
 
@@ -530,22 +533,12 @@ async fn run_node<S>(
                 info!("Waiting until node reaches height {target_height}");
 
                 'inner: while let Ok(event) = rx_event.recv().await {
-                    match &event {
-                        Event::StartedHeight(height) => {
-                            info!("Node started height {height}");
+                    if let Event::StartedHeight(height) = &event {
+                        info!("Node started height {height}");
 
-                            if height.as_u64() == target_height {
-                                break 'inner;
-                            }
+                        if height.as_u64() == target_height {
+                            break 'inner;
                         }
-                        Event::WalReplayError(e) => {
-                            actor_ref.stop(Some(format!("WAL replay error: {}", e)));
-                            handle.abort();
-                            bg.abort();
-
-                            return TestResult::Failure(format!("WAL replay error: {}", e));
-                        }
-                        _ => (),
                     }
                 }
             }

--- a/code/crates/starknet/test/src/lib.rs
+++ b/code/crates/starknet/test/src/lib.rs
@@ -538,12 +538,12 @@ async fn run_node<S>(
                                 break 'inner;
                             }
                         }
-                        Event::WalReplayError => {
-                            actor_ref.stop(Some("WAL replay error".to_string()));
+                        Event::WalReplayError(e) => {
+                            actor_ref.stop(Some(format!("WAL replay error: {}", e)));
                             handle.abort();
                             bg.abort();
 
-                            return TestResult::Failure("WAL replay error".to_string());
+                            return TestResult::Failure(format!("WAL replay error: {}", e));
                         }
                         _ => (),
                     }

--- a/code/crates/starknet/test/src/tests/vote_sync.rs
+++ b/code/crates/starknet/test/src/tests/vote_sync.rs
@@ -144,7 +144,7 @@ pub async fn start_late() {
 pub async fn crash_restart_after_vote_set_request() {
     init_logging(module_path!());
 
-    const HEIGHT: u64 = 4;
+    const HEIGHT: u64 = 3;
 
     let mut test = TestBuilder::<()>::new();
 
@@ -158,7 +158,7 @@ pub async fn crash_restart_after_vote_set_request() {
         // Wait for a vote set request for height 2
         .expect_vote_set_request(2)
         .crash()
-        // Restart again with W
+        // Restart again
         .restart_after(Duration::from_secs(5))
         .wait_until(HEIGHT)
         .success();

--- a/code/crates/starknet/test/src/tests/vote_sync.rs
+++ b/code/crates/starknet/test/src/tests/vote_sync.rs
@@ -94,9 +94,6 @@ pub async fn crash_restart_from_latest() {
         .restart_after(Duration::from_secs(5))
         // Expect a vote set request for height 2
         .expect_vote_set_request(2)
-        .crash()
-        // We do not reset the database so that the node can restart from the latest height
-        .restart_after(Duration::from_secs(5))
         .wait_until(HEIGHT)
         .success();
 
@@ -125,41 +122,6 @@ pub async fn start_late() {
         .start_after(1, Duration::from_secs(10))
         // Expect a vote set request for height 1
         .expect_vote_set_request(1)
-        .wait_until(HEIGHT)
-        .success();
-
-    test.build()
-        .run_with_custom_config(
-            Duration::from_secs(60),
-            TestParams {
-                enable_sync: true,
-                timeout_step: Duration::from_secs(5),
-                ..Default::default()
-            },
-        )
-        .await
-}
-
-#[tokio::test]
-pub async fn crash_restart_after_vote_set_request() {
-    init_logging(module_path!());
-
-    const HEIGHT: u64 = 3;
-
-    let mut test = TestBuilder::<()>::new();
-
-    test.add_node().start().wait_until(HEIGHT).success();
-    test.add_node()
-        .start()
-        .wait_until(2)
-        .crash()
-        // Restart from the latest height
-        .restart_after(Duration::from_secs(5))
-        // Wait for a vote set request for height 2
-        .expect_vote_set_request(2)
-        .crash()
-        // Restart again
-        .restart_after(Duration::from_secs(5))
         .wait_until(HEIGHT)
         .success();
 

--- a/code/crates/starknet/test/src/tests/wal.rs
+++ b/code/crates/starknet/test/src/tests/wal.rs
@@ -192,3 +192,38 @@ async fn non_proposer_crashes_after_voting(params: TestParams) {
         )
         .await
 }
+
+#[tokio::test]
+pub async fn node_crashes_after_vote_set_request() {
+    init_logging(module_path!());
+
+    const HEIGHT: u64 = 3;
+
+    let mut test = TestBuilder::<()>::new();
+
+    test.add_node().start().wait_until(HEIGHT).success();
+    test.add_node()
+        .start()
+        .wait_until(2)
+        .crash()
+        // Restart from the latest height
+        .restart_after(Duration::from_secs(5))
+        // Wait for a vote set request for height 2
+        .expect_vote_set_request(2)
+        .crash()
+        // Restart again
+        .restart_after(Duration::from_secs(5))
+        .wait_until(HEIGHT)
+        .success();
+
+    test.build()
+        .run_with_custom_config(
+            Duration::from_secs(60),
+            TestParams {
+                enable_sync: true,
+                timeout_step: Duration::from_secs(5),
+                ..Default::default()
+            },
+        )
+        .await
+}


### PR DESCRIPTION
Closes: #XXX
Sometime wal entries fail to decode with errors like this:
```
2025-02-07T20:30:44.054030Z ERROR node{moniker=test-2}:wal{height=144}: Failed to decode WAL entry 4: failed to fill whole buffer
```
Looks like for `PrevoteTimeLimit` and `PrecommitTimeLimit` we still write something to the WAL (just the tag) and later fail to decode.
 - [x] Add test that shows the error
 - [x] Fix the error
      
Note: A better fix might be to move the entry filtering logic in consensus who would decide which entries should be logged. For timeouts it could check the type [here](https://github.com/informalsystems/malachite/blob/fec4b6ed39637db75d742a7bf002eb9b56008e9f/code/crates/engine/src/consensus.rs#L1049-L1053)


---

### PR author checklist

#### For all contributors

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
