### PR TITLE
fix(code/core-consensus): Only cancel propose timeout on a step change

### DIFF
--- a/code/crates/core-consensus/src/handle/driver.rs
+++ b/code/crates/core-consensus/src/handle/driver.rs
@@ -50,11 +50,6 @@ where
 
                 return Ok(());
             }
-
-            perform!(
-                co,
-                Effect::CancelTimeout(Timeout::propose(proposal.round()), Default::default())
-            );
         }
 
         DriverInput::Vote(vote) => {
@@ -117,6 +112,13 @@ where
 
     if prev_step != new_step {
         if state.driver.step_is_prevote() {
+            // Cancel the Propose timeout since we have moved from Propose to Prevote
+            perform!(
+                co,
+                Effect::CancelTimeout(Timeout::propose(state.driver.round()), Default::default())
+            );
+
+            // Schedule the Prevote time limit timeout
             perform!(
                 co,
                 Effect::ScheduleTimeout(

--- a/code/crates/core-driver/src/mux.rs
+++ b/code/crates/core-driver/src/mux.rs
@@ -161,7 +161,16 @@ where
             return Some(RoundInput::ProposalAndPolkaPrevious(proposal));
         }
 
-        Some(RoundInput::Proposal(proposal))
+        if proposal.pol_round().is_nil() {
+            // L22
+            return Some(RoundInput::Proposal(proposal));
+        }
+
+        // We have `vr >= 0` without a  matching polka from round `vr`,
+        // so we do not do anything and wait either:
+        // - For more votes to arrive and form a polka
+        // - For the Propose timeout to expire, prevote nil and move to prevote
+        None
     }
 
     pub(crate) fn store_and_multiplex_proposal(

--- a/code/crates/core-types/src/round.rs
+++ b/code/crates/core-types/src/round.rs
@@ -47,7 +47,7 @@ impl Round {
         matches!(self, Round::Some(_))
     }
 
-    /// Whether the round is nil, ie. `r == 0`.
+    /// Whether the round is nil, ie. `r == -1`.
     pub fn is_nil(&self) -> bool {
         matches!(self, Round::Nil)
     }


### PR DESCRIPTION
See: #850

> @ancazamfir: When a `Proposal(h, r, v, vr)` is received without a `PolkaPrevious`, consensus cancels the propose timeout therefore never reaching the Prevote step and starting vote sync. (https://github.com/informalsystems/malachite/issues/850#issuecomment-2659910086)

When receiving a proposal `⁠Proposal(h, r, v, vr)` with `⁠vr > -1` without a polka for `vr`, we must:

1. Stay in the Propose step
2. Keep the Propose timeout active to either:
   - Collect more votes to form a polka, prevote `⁠v` and move to the Prevote step
   - Let the Propose timeout expire, prevote ⁠`nil` and move to the Prevote step

Previously, we were incorrectly cancelling the Propose timeout in all cases, including that one, violating (2).

---

### PR author checklist

#### For all contributors

- [x] Reference GitHub issue
- [x] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
