### PR TITLE
fix(code/engine): Use custom version of `OutputPort` with configurable capacity

### DIFF
--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -62,6 +62,9 @@ debug = true
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
+[workspace.lints.clippy]
+disallowed_types = "deny"
+
 [workspace.dependencies]
 malachitebft-engine             = { version = "0.0.1", package = "informalsystems-malachitebft-engine", path = "crates/engine" }
 malachitebft-app                = { version = "0.0.1", package = "informalsystems-malachitebft-app", path = "crates/app" }

--- a/code/clippy.toml
+++ b/code/clippy.toml
@@ -1,1 +1,7 @@
 msrv = "1.83.0"
+disallowed-types = [
+  "ractor::port::OutputPort",
+  "ractor::port::OutputPortSubscriber",
+  "ractor::port::OutputPortSubscriber",
+  ".."
+]

--- a/code/crates/engine/src/network.rs
+++ b/code/crates/engine/src/network.rs
@@ -6,8 +6,7 @@ use derive_where::derive_where;
 use eyre::eyre;
 use libp2p::identity::Keypair;
 use libp2p::request_response;
-use ractor::port::OutputPortSubscriberTrait;
-use ractor::{Actor, ActorProcessingErr, ActorRef, OutputPort, RpcReplyPort};
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
 use tokio::task::JoinHandle;
 use tracing::{error, trace};
 
@@ -24,6 +23,7 @@ use malachitebft_network::{Channel, Config, Event, Multiaddr, PeerId};
 
 use crate::consensus::ConsensusCodec;
 use crate::sync::SyncCodec;
+use crate::util::output_port::{OutputPort, OutputPortSubscriberTrait};
 use crate::util::streaming::StreamMessage;
 
 pub type NetworkRef<Ctx> = ActorRef<Msg<Ctx>>;
@@ -203,7 +203,7 @@ where
         Ok(State::Running {
             listen_addrs: Vec::new(),
             peers: BTreeSet::new(),
-            output_port: OutputPort::default(),
+            output_port: OutputPort::with_capacity(128),
             ctrl_handle,
             recv_task,
             inbound_requests: HashMap::new(),

--- a/code/crates/engine/src/util/mod.rs
+++ b/code/crates/engine/src/util/mod.rs
@@ -1,5 +1,6 @@
 pub mod events;
 pub mod msg_buffer;
+pub mod output_port;
 pub mod streaming;
 pub mod ticker;
 pub mod timers;

--- a/code/crates/engine/src/util/output_port.rs
+++ b/code/crates/engine/src/util/output_port.rs
@@ -1,0 +1,330 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! Output ports for publish-subscribe notifications between actors
+//!
+//! This notion extends beyond traditional actors in this that is a publish-subscribe
+//! mechanism we've added in `ractor`. Output ports are ports which can have messages published
+//! to them which are automatically forwarded to downstream actors waiting for inputs. They optionally
+//! have a message transformer attached to them to convert them to the appropriate message type
+
+use std::sync::RwLock;
+
+use ractor::concurrency::JoinHandle;
+use ractor::{ActorRef, Message};
+use tokio::sync::broadcast as pubsub;
+
+/// Output messages, since they need to be replicated, require [Clone] in addition
+/// to the base [Message] constraints
+pub trait OutputMessage: Message + Clone {}
+impl<T: Message + Clone> OutputMessage for T {}
+
+/// An [OutputPort] is a publish-subscribe mechanism for connecting actors together.
+/// It allows actors to emit messages without knowing which downstream actors are subscribed.
+///
+/// You can subscribe to the output port with an [ActorRef] and a message converter from the output
+/// type to the actor's expected input type. If the actor is dropped or stops, the subscription will
+/// be dropped and if the output port is dropped, then the subscription will also be dropped
+/// automatically.
+pub struct OutputPort<TMsg>
+where
+    TMsg: OutputMessage,
+{
+    tx: pubsub::Sender<Option<TMsg>>,
+    subscriptions: RwLock<Vec<OutputPortSubscription>>,
+}
+
+impl<TMsg> Default for OutputPort<TMsg>
+where
+    TMsg: OutputMessage,
+{
+    fn default() -> Self {
+        // We only need enough buffer for the subscription task to forward to the input port
+        // of the receiving actor. Hence 10 should be plenty.
+        Self::with_capacity(10)
+    }
+}
+
+impl<TMsg> OutputPort<TMsg>
+where
+    TMsg: OutputMessage,
+{
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        let (tx, _rx) = pubsub::channel(capacity);
+        Self {
+            tx,
+            subscriptions: RwLock::new(vec![]),
+        }
+    }
+
+    /// Subscribe to the output port, passing in a converter to convert to the input message
+    /// of another actor
+    ///
+    /// * `receiver` - The reference to the actor which will receive forwarded messages
+    /// * `converter` - The converter which will convert the output message type to the
+    ///   receiver's input type and return [Some(_)] if the message should be forwarded, [None]
+    ///   if the message should be skipped.
+    pub fn subscribe<TReceiverMsg, F>(&self, receiver: ActorRef<TReceiverMsg>, converter: F)
+    where
+        F: Fn(TMsg) -> Option<TReceiverMsg> + Send + 'static,
+        TReceiverMsg: Message,
+    {
+        let mut subs = self.subscriptions.write().unwrap();
+
+        // filter out dead subscriptions, since they're no longer valid
+        subs.retain(|sub| !sub.is_dead());
+
+        let sub = OutputPortSubscription::new::<TMsg, F, TReceiverMsg>(
+            self.tx.subscribe(),
+            converter,
+            receiver,
+        );
+        subs.push(sub);
+    }
+
+    /// Send a message on the output port
+    ///
+    /// * `msg`: The message to send
+    pub fn send(&self, msg: TMsg) {
+        if self.tx.receiver_count() > 0 {
+            let _ = self.tx.send(Some(msg));
+        }
+    }
+}
+
+impl<TMsg> Drop for OutputPort<TMsg>
+where
+    TMsg: OutputMessage,
+{
+    fn drop(&mut self) {
+        let mut subs = self.subscriptions.write().unwrap();
+        for sub in subs.iter_mut() {
+            sub.stop();
+        }
+        subs.clear();
+    }
+}
+
+// ============== Subscription implementation ============== //
+
+/// The output port's subscription handle. It holds a handle to a [JoinHandle]
+/// which listens to the [pubsub::Receiver] to see if there's a new message, and if there is
+/// forwards it to the [ActorRef] asynchronously using the specified converter.
+struct OutputPortSubscription {
+    handle: JoinHandle<()>,
+}
+
+impl OutputPortSubscription {
+    /// Determine if the subscription is dead
+    pub fn is_dead(&self) -> bool {
+        self.handle.is_finished()
+    }
+
+    /// Stop the subscription, by aborting the underlying [JoinHandle]
+    pub fn stop(&mut self) {
+        self.handle.abort();
+    }
+
+    /// Create a new subscription
+    pub fn new<TMsg, F, TReceiverMsg>(
+        mut port: pubsub::Receiver<Option<TMsg>>,
+        converter: F,
+        receiver: ActorRef<TReceiverMsg>,
+    ) -> Self
+    where
+        TMsg: OutputMessage,
+        F: Fn(TMsg) -> Option<TReceiverMsg> + Send + 'static,
+        TReceiverMsg: Message,
+    {
+        let handle = ractor::concurrency::spawn(async move {
+            loop {
+                match port.recv().await {
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(l)) => {
+                        tracing::warn!("Output port is lagging, we've dropped {l} messages!");
+                    }
+                    Ok(Some(msg)) => {
+                        if let Some(new_msg) = converter(msg) {
+                            if receiver.cast(new_msg).is_err() {
+                                // kill the subscription process, as the forwarding agent is stopped
+                                return;
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        // skip this message
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        tracing::warn!("Subscription is dying due to closed channel!");
+                        return;
+                    }
+                }
+            }
+        });
+
+        Self { handle }
+    }
+}
+
+/// Represents a boxed `ActorRef` subscriber capable of handling messages from a
+/// publisher via an `OutputPort`, employing a publish-subscribe pattern to
+/// decouple message broadcasting from handling. For a subscriber `ActorRef` to
+/// function as an `OutputPortSubscriber<T>`, its message type must implement
+/// `From<T>` to convert the published message type to its own message format.
+///
+/// # Example
+/// ```
+/// // First, define the publisher's message types, including a variant for
+/// // subscribing `OutputPortSubscriber`s and another for publishing messages:
+/// use ractor::{
+///     cast,
+///     port::{OutputPort, OutputPortSubscriber},
+///     Actor, ActorProcessingErr, ActorRef, Message,
+/// };
+///
+/// enum PublisherMessage {
+///     Publish(u8),                         // Message type for publishing
+///     Subscribe(OutputPortSubscriber<u8>), // Message type for subscribing an actor to the output port
+/// }
+///
+/// #[cfg(feature = "cluster")]
+/// impl Message for PublisherMessage {
+///     fn serializable() -> bool {
+///         false
+///     }
+/// }
+///
+/// // In the publisher actor's `handle` function, handle subscription requests and
+/// // publish messages accordingly:
+///
+/// struct Publisher;
+/// struct State {
+///     output_port: OutputPort<u8>,
+/// }
+///
+/// #[cfg_attr(feature = "async-trait", ractor::async_trait)]
+/// impl Actor for Publisher {
+///     type State = State;
+///     type Msg = PublisherMessage;
+///     type Arguments = ();
+///
+///     async fn pre_start(
+///         &self,
+///         _myself: ActorRef<Self::Msg>,
+///         _: (),
+///     ) -> Result<Self::State, ActorProcessingErr> {
+///         Ok(State {
+///             output_port: OutputPort::default(),
+///         })
+///     }
+///
+///     async fn handle(
+///         &self,
+///         _myself: ActorRef<Self::Msg>,
+///         message: Self::Msg,
+///         state: &mut Self::State,
+///     ) -> Result<(), ActorProcessingErr> {
+///         match message {
+///             PublisherMessage::Subscribe(subscriber) => {
+///                 // Subscribes the `OutputPortSubscriber` wrapped actor to the `OutputPort`
+///                 subscriber.subscribe_to_port(&state.output_port);
+///             }
+///             PublisherMessage::Publish(value) => {
+///                 // Broadcasts the `u8` value to all subscribed actors, which will handle the type conversion
+///                 state.output_port.send(value);
+///             }
+///         }
+///         Ok(())
+///     }
+/// }
+///
+/// // The subscriber's message type demonstrates how to transform the publisher's
+/// // message type by implementing `From<T>`:
+///
+/// #[derive(Debug)]
+/// enum SubscriberMessage {
+///     Handle(String), // Subscriber's intent for message handling
+/// }
+///
+/// #[cfg(feature = "cluster")]
+/// impl Message for SubscriberMessage {
+///     fn serializable() -> bool {
+///         false
+///     }
+/// }
+///
+/// impl From<u8> for SubscriberMessage {
+///     fn from(value: u8) -> Self {
+///         SubscriberMessage::Handle(value.to_string()) // Converts u8 to String
+///     }
+/// }
+///
+/// // To subscribe a subscriber actor to the publisher and broadcast a message:
+/// struct Subscriber;
+/// #[cfg_attr(feature = "async-trait", ractor::async_trait)]
+/// impl Actor for Subscriber {
+///     type State = ();
+///     type Msg = SubscriberMessage;
+///     type Arguments = ();
+///
+///     async fn pre_start(
+///         &self,
+///         _myself: ActorRef<Self::Msg>,
+///         _: (),
+///     ) -> Result<Self::State, ActorProcessingErr> {
+///         Ok(())
+///     }
+///
+///     async fn handle(
+///         &self,
+///         _myself: ActorRef<Self::Msg>,
+///         message: Self::Msg,
+///         _state: &mut Self::State,
+///     ) -> Result<(), ActorProcessingErr> {
+///         Ok(())
+///     }
+/// }
+/// async fn example() {
+///     let (publisher_actor_ref, publisher_actor_handle) =
+///         Actor::spawn(None, Publisher, ()).await.unwrap();
+///     let (subscriber_actor_ref, subscriber_actor_handle) =
+///         Actor::spawn(None, Subscriber, ()).await.unwrap();
+///
+///     publisher_actor_ref
+///         .send_message(PublisherMessage::Subscribe(Box::new(subscriber_actor_ref)))
+///         .unwrap();
+///
+///     // Broadcasting a message to all subscribers
+///     publisher_actor_ref
+///         .send_message(PublisherMessage::Publish(123))
+///         .unwrap();
+///
+///     publisher_actor_handle.await.unwrap();
+///     subscriber_actor_handle.await.unwrap();
+/// }
+/// ```
+pub type OutputPortSubscriber<InputMessage> = Box<dyn OutputPortSubscriberTrait<InputMessage>>;
+
+/// A trait for subscribing to an [OutputPort]
+pub trait OutputPortSubscriberTrait<I>: Send
+where
+    I: Message + Clone,
+{
+    /// Subscribe to the output port
+    fn subscribe_to_port(&self, port: &OutputPort<I>);
+}
+
+impl<I, O> OutputPortSubscriberTrait<I> for ActorRef<O>
+where
+    I: Message + Clone,
+    O: Message + From<I>,
+{
+    fn subscribe_to_port(&self, port: &OutputPort<I>) {
+        port.subscribe(self.clone(), |msg| Some(O::from(msg)));
+    }
+}

--- a/code/crates/engine/src/util/timers.rs
+++ b/code/crates/engine/src/util/timers.rs
@@ -6,10 +6,10 @@ use std::ops::RangeFrom;
 use std::sync::Arc;
 use std::time::Duration;
 
-use ractor::port::OutputPortSubscriber;
-use ractor::OutputPort;
 use tokio::task::JoinHandle;
 use tracing::trace;
+
+use super::output_port::{OutputPort, OutputPortSubscriber};
 
 #[derive(Debug)]
 struct Timer<Key> {
@@ -30,7 +30,6 @@ pub struct TimeoutElapsed<Key> {
     generation: u64,
 }
 
-#[derive(Debug)]
 pub struct TimerScheduler<Key>
 where
     Key: Clone + Eq + Hash + Send + 'static,
@@ -45,7 +44,7 @@ where
     Key: Clone + Eq + Hash + Send + 'static,
 {
     pub fn new(subscriber: OutputPortSubscriber<TimeoutElapsed<Key>>) -> Self {
-        let output_port = OutputPort::default();
+        let output_port = OutputPort::with_capacity(32);
         subscriber.subscribe_to_port(&output_port);
 
         Self {

--- a/code/crates/starknet/host/src/mempool/network.rs
+++ b/code/crates/starknet/host/src/mempool/network.rs
@@ -3,14 +3,13 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use libp2p_identity::Keypair;
-use ractor::port::OutputPortSubscriber;
 use ractor::ActorProcessingErr;
 use ractor::ActorRef;
-use ractor::OutputPort;
 use ractor::{Actor, RpcReplyPort};
 use tokio::task::JoinHandle;
 use tracing::error;
 
+use malachitebft_engine::util::output_port::{OutputPort, OutputPortSubscriber};
 use malachitebft_metrics::SharedRegistry;
 use malachitebft_test_mempool::handle::CtrlHandle;
 use malachitebft_test_mempool::types::MempoolTransactionBatch;


### PR DESCRIPTION
See `https://github.com/slawlor/ractor/issues/225` for background info

With this PR, the OutputPort will log a warning if it runs into backpressure issues and drops messages.

It also bumps the capacity of the network output port from 10 to 128 and the one for timers from 10 to 64.

---

### PR author checklist

#### For all contributors

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
