### PR TITLE
fix(code/engine): Ensure the height in the tracing span matches the height we are about to start

### DIFF
--- a/code/crates/app-channel/src/run.rs
+++ b/code/crates/app-channel/src/run.rs
@@ -15,7 +15,6 @@ use crate::app::types::core::Context;
 use crate::spawn::{spawn_host_actor, spawn_network_actor};
 use crate::Channels;
 
-#[tracing::instrument("node", skip_all, fields(moniker = %cfg.moniker()))]
 pub async fn start_engine<Node, Ctx, Codec>(
     ctx: Ctx,
     codec: Codec,

--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -1167,8 +1167,8 @@ where
         parent = &self.span,
         skip_all,
         fields(
-            height = %state.consensus.height(),
-            round = %state.consensus.round()
+            height = %span_height(state.consensus.height(), &msg),
+            round = %span_round(state.consensus.round(), &msg)
         )
     )]
     async fn handle(
@@ -1219,4 +1219,24 @@ fn should_buffer<Ctx: Context>(msg: &Msg<Ctx>) -> bool {
             | Msg::NetworkEvent(NetworkEvent::PeerConnected(..))
             | Msg::NetworkEvent(NetworkEvent::PeerDisconnected(..))
     )
+}
+
+/// Use the height we are about to start instead of the consensus state height
+/// for the tracing span of the Consensus actor when starting a new height.
+fn span_height<Ctx: Context>(height: Ctx::Height, msg: &Msg<Ctx>) -> Ctx::Height {
+    if let Msg::StartHeight(h, _) = msg {
+        *h
+    } else {
+        height
+    }
+}
+
+/// Use round 0 instead of the consensus state round for the tracing span of
+/// the Consensus actor when starting a new height.
+fn span_round<Ctx: Context>(round: Round, msg: &Msg<Ctx>) -> Round {
+    if let Msg::StartHeight(_, _) = msg {
+        Round::new(0)
+    } else {
+        round
+    }
 }

--- a/code/crates/engine/src/wal.rs
+++ b/code/crates/engine/src/wal.rs
@@ -214,7 +214,7 @@ where
         name = "wal",
         parent = &self.span,
         skip_all,
-        fields(height = %state.height),
+        fields(height = %span_height(state.height, &msg)),
     )]
     async fn handle(
         &self,
@@ -245,5 +245,15 @@ where
         let _ = state.wal_sender.send(self::thread::WalMsg::Shutdown).await;
 
         Ok(())
+    }
+}
+
+/// Use the height we are about to start instead of the current height
+/// for the tracing span of the WAL actor when starting a new height.
+fn span_height<Ctx: Context>(height: Ctx::Height, msg: &Msg<Ctx>) -> Ctx::Height {
+    if let Msg::StartedHeight(h, _) = msg {
+        *h
+    } else {
+        height
     }
 }

--- a/code/crates/engine/src/wal/thread.rs
+++ b/code/crates/engine/src/wal/thread.rs
@@ -44,7 +44,12 @@ where
     })
 }
 
-#[tracing::instrument(name = "wal", parent = span, skip_all, fields(height = log.sequence()))]
+#[tracing::instrument(
+    name = "wal",
+    parent = span,
+    skip_all,
+    fields(height = span_sequence(log.sequence(), &msg))
+)]
 fn process_msg<Ctx, Codec>(
     msg: WalMsg<Ctx>,
     span: &tracing::Span,
@@ -173,5 +178,13 @@ where
         ))
     } else {
         Ok(entries)
+    }
+}
+
+fn span_sequence(sequence: u64, msg: &WalMsg<impl Context>) -> u64 {
+    if let WalMsg::StartedHeight(height, _) = msg {
+        height.as_u64()
+    } else {
+        sequence
     }
 }


### PR DESCRIPTION
Closes: #888 

### Before

```
INFO  node{moniker=app-2}:consensus{height=1 round=0}: Starting new height height=2
INFO  node{moniker=app-2}:consensus{height=1 round=0}: Starting new round height=2 round=0 proposer=CC15EF77...
DEBUG node{moniker=app-2}:wal{height=1}: Flushed WAL to disk wal.entries=7 wal.size=821
DEBUG node{moniker=app-2}:wal{height=1}: Reset WAL height=2
DEBUG node{moniker=app-2}:consensus{height=1 round=0}: No WAL entries to replay height=2
```

### After

```
INFO  node{moniker=app-2}:consensus{height=2 round=0}: Starting new height height=2
INFO  node{moniker=app-2}:consensus{height=2 round=0}: Starting new round height=2 round=0 proposer=CC15EF77..
DEBUG node{moniker=app-2}:wal{height=1}: Flushed WAL to disk wal.entries=7 wal.size=821
DEBUG node{moniker=app-2}:wal{height=2}: Reset WAL height=2
DEBUG node{moniker=app-2}:consensus{height=2 round=0}: No WAL entries to replay height=2
```

---

### PR author checklist

#### For all contributors

- [x] Reference GitHub issue
- [x] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
