### PR TITLE
fix(code/discovery): Simplified disabled discovery + reduced logs verbosity

### DIFF
--- a/code/crates/config/src/lib.rs
+++ b/code/crates/config/src/lib.rs
@@ -48,7 +48,7 @@ impl Default for P2pConfig {
     }
 }
 /// Peer Discovery configuration options
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DiscoveryConfig {
     /// Enable peer discovery
     #[serde(default)]
@@ -74,6 +74,19 @@ pub struct DiscoveryConfig {
     #[serde(default)]
     #[serde(with = "humantime_serde")]
     pub ephemeral_connection_timeout: Duration,
+}
+
+impl Default for DiscoveryConfig {
+    fn default() -> Self {
+        DiscoveryConfig {
+            enabled: false,
+            bootstrap_protocol: Default::default(),
+            selector: Default::default(),
+            num_outbound_peers: 0,
+            num_inbound_peers: 20,
+            ephemeral_connection_timeout: Default::default(),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]

--- a/code/crates/discovery/src/handlers/close.rs
+++ b/code/crates/discovery/src/handlers/close.rs
@@ -1,5 +1,5 @@
 use libp2p::{swarm::ConnectionId, PeerId, Swarm};
-use tracing::{error, info, warn};
+use tracing::{debug, error, warn};
 
 use crate::{Discovery, DiscoveryClient, State};
 
@@ -35,7 +35,7 @@ where
             .is_some_and(|connections| connections.contains(&connection_id))
         {
             if swarm.close_connection(connection_id) {
-                info!("Closing connection {connection_id} to peer {peer_id}");
+                debug!("Closing connection {connection_id} to peer {peer_id}");
             } else {
                 error!("Error closing connection {connection_id} to peer {peer_id}");
             }

--- a/code/crates/discovery/src/handlers/dial.rs
+++ b/code/crates/discovery/src/handlers/dial.rs
@@ -1,5 +1,5 @@
 use libp2p::{core::ConnectedPoint, swarm::ConnectionId, PeerId, Swarm};
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 use crate::{connection::ConnectionData, controller::PeerData, Discovery, DiscoveryClient};
 
@@ -50,7 +50,7 @@ where
             self.metrics.increment_total_dials();
         }
 
-        info!(
+        debug!(
             "Dialing peer at {}, retry #{}",
             connection_data.multiaddr(),
             connection_data.retry.count()

--- a/code/crates/discovery/src/handlers/dial.rs
+++ b/code/crates/discovery/src/handlers/dial.rs
@@ -85,12 +85,10 @@ where
     ) {
         match endpoint {
             ConnectedPoint::Dialer { .. } => {
-                debug!("Connected to {peer_id} with connection {connection_id}");
+                debug!(peer = %peer_id, %connection_id, "Connected to peer");
             }
             ConnectedPoint::Listener { .. } => {
-                debug!(
-                    "Accepted incoming connection from {peer_id} with connection {connection_id}"
-                );
+                debug!(peer = %peer_id, %connection_id, "Accepted incoming connection from peer");
             }
         }
 

--- a/code/crates/discovery/src/handlers/extension.rs
+++ b/code/crates/discovery/src/handlers/extension.rs
@@ -1,5 +1,5 @@
 use libp2p::{PeerId, Swarm};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{request::RequestData, Discovery, DiscoveryClient, State};
 
@@ -16,7 +16,7 @@ where
 
     pub(crate) fn initiate_extension_with_target(&mut self, swarm: &mut Swarm<C>, target: usize) {
         if let State::Extending(curr_target) = self.state {
-            info!(
+            debug!(
                 "Updating extension target from {} to {}",
                 curr_target,
                 curr_target + target
@@ -26,7 +26,7 @@ where
             return;
         }
 
-        info!(
+        debug!(
             "Initiating discovery extension with a target of {} peers",
             target
         );
@@ -63,7 +63,7 @@ where
                 < target
             {
                 if let Some(peer_id) = self.get_next_peer_to_peers_request() {
-                    info!(
+                    debug!(
                         "Discovery extension in progress ({}ms), requesting peers from peer {}",
                         self.metrics.elapsed().as_millis(),
                         peer_id
@@ -91,7 +91,7 @@ where
 
             self.state = State::Idle;
         } else {
-            info!("Discovery extension in progress ({}ms), {} pending connections ({} in queue), {} pending requests ({} in queue)",
+            debug!("Discovery extension in progress ({}ms), {} pending connections ({} in queue), {} pending requests ({} in queue)",
                 self.metrics.elapsed().as_millis(),
                 pending_connections_len,
                 rx_dial_len,

--- a/code/crates/discovery/src/handlers/helpers.rs
+++ b/code/crates/discovery/src/handlers/helpers.rs
@@ -14,9 +14,16 @@ where
     }
 
     pub(crate) fn update_connections_metrics(&mut self) {
+        let num_inbound_connections = self.inbound_connections.len();
+
+        if !self.is_enabled() {
+            info!("Connections: {}", num_inbound_connections);
+
+            return;
+        }
+
         let num_active_connections = self.active_connections_len();
         let num_outbound_connections = self.outbound_connections.len();
-        let num_inbound_connections = self.inbound_connections.len();
         let num_ephemeral_connections = num_active_connections
             .saturating_sub(num_outbound_connections + num_inbound_connections);
 

--- a/code/crates/discovery/src/handlers/helpers.rs
+++ b/code/crates/discovery/src/handlers/helpers.rs
@@ -15,26 +15,23 @@ where
 
     pub(crate) fn update_connections_metrics(&mut self) {
         let num_inbound_connections = self.inbound_connections.len();
-
-        if !self.is_enabled() {
-            info!("Connections: {}", num_inbound_connections);
-
-            return;
-        }
-
         let num_active_connections = self.active_connections_len();
         let num_outbound_connections = self.outbound_connections.len();
         let num_ephemeral_connections = num_active_connections
             .saturating_sub(num_outbound_connections + num_inbound_connections);
 
-        info!(
-            "Active connections: {} (duplicates: {}), Outbound connections: {}, Inbound connections: {}, Ephemeral connections: {}",
-            num_active_connections,
-            self.active_connections_num_duplicates(),
-            num_outbound_connections,
-            num_inbound_connections,
-            num_ephemeral_connections,
-        );
+        if !self.is_enabled() {
+            info!("Connections: {}", num_inbound_connections);
+        } else {
+            info!(
+                "Active connections: {} (duplicates: {}), Outbound connections: {}, Inbound connections: {}, Ephemeral connections: {}",
+                num_active_connections,
+                self.active_connections_num_duplicates(),
+                num_outbound_connections,
+                num_inbound_connections,
+                num_ephemeral_connections,
+            );
+        }
 
         self.metrics.set_connections_status(
             num_active_connections,

--- a/code/crates/discovery/src/handlers/identify.rs
+++ b/code/crates/discovery/src/handlers/identify.rs
@@ -1,5 +1,5 @@
 use libp2p::{identify, swarm::ConnectionId, PeerId, Swarm};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::config::BootstrapProtocol;
 use crate::{request::RequestData, Discovery, DiscoveryClient, OutboundConnection, State};
@@ -8,12 +8,6 @@ impl<C> Discovery<C>
 where
     C: DiscoveryClient,
 {
-    fn is_bootstrap_node(&self, peer_id: &PeerId) -> bool {
-        self.bootstrap_nodes
-            .iter()
-            .any(|(id, _)| id.as_ref() == Some(peer_id))
-    }
-
     pub fn handle_new_peer(
         &mut self,
         swarm: &mut Swarm<C>,
@@ -62,7 +56,7 @@ where
         }
 
         if let Some(connection_ids) = self.active_connections.get_mut(&peer_id) {
-            warn!(
+            debug!(
                 "Additional connection {connection_id} to peer {peer_id}, total connections: {}",
                 connection_ids.len() + 1
             );
@@ -81,7 +75,7 @@ where
                 // This case happens when the peer was selected to be part of the outbound connections
                 // but no connection was established yet. No need to trigger a connect request, it
                 // was already done during the selection process.
-                info!("Connection {connection_id} from peer {peer_id} is outbound (pending connect request)");
+                debug!("Connection {connection_id} from peer {peer_id} is outbound (pending connect request)");
 
                 if let Some(out_conn) = self.outbound_connections.get_mut(&peer_id) {
                     out_conn.connection_id = Some(connection_id);
@@ -94,7 +88,7 @@ where
                 // If the initial discovery process is done and did not find enough peers,
                 // the connection is outbound, otherwise it is ephemeral, except if later
                 // the connection is requested to be persistent (inbound).
-                info!("Connection {connection_id} from peer {peer_id} is outbound (incomplete initial discovery)");
+                debug!("Connection {connection_id} from peer {peer_id} is outbound (incomplete initial discovery)");
 
                 self.outbound_connections.insert(
                     peer_id,
@@ -109,10 +103,10 @@ where
                     .add_to_queue(RequestData::new(peer_id), None);
 
                 if self.outbound_connections.len() >= self.config.num_outbound_peers {
-                    info!("Minimum number of peers reached");
+                    debug!("Minimum number of peers reached");
                 }
             } else {
-                info!("Connection {connection_id} from peer {peer_id} is ephemeral");
+                debug!("Connection {connection_id} from peer {peer_id} is ephemeral");
 
                 self.controller.close.add_to_queue(
                     (peer_id, connection_id),
@@ -131,30 +125,19 @@ where
                     .add_address(&peer_id, info.listen_addrs.first().unwrap().clone());
             }
         } else {
-            // If discovery is disabled, connections to bootstrap nodes are outbound,
-            // and all other connections are ephemeral, except if later the connections
-            // are requested to be persistent (inbound).
-            if self.is_bootstrap_node(&peer_id) {
-                info!("Connection {connection_id} from bootstrap node {peer_id} is outbound, requesting persistent connection");
+            // If discovery is disabled, all connections are inbound. The
+            // maximum number of inbound connections is enforced by the
+            // corresponding parameter in the configuration.
+            if self.inbound_connections.len() < self.config.num_inbound_peers {
+                debug!("Connection {connection_id} from peer {peer_id} is inbound");
 
-                self.outbound_connections.insert(
-                    peer_id,
-                    OutboundConnection {
-                        connection_id: None, // Will be set once the response is received
-                        is_persistent: false,
-                    },
-                );
+                self.inbound_connections.insert(peer_id, connection_id);
+            } else {
+                warn!("Connections limit reached, refusing connection {connection_id} from peer {peer_id}");
 
                 self.controller
-                    .connect_request
-                    .add_to_queue(RequestData::new(peer_id), None);
-            } else {
-                info!("Connection {connection_id} from peer {peer_id} is ephemeral");
-
-                self.controller.close.add_to_queue(
-                    (peer_id, connection_id),
-                    Some(self.config.ephemeral_connection_timeout),
-                );
+                    .close
+                    .add_to_queue((peer_id, connection_id), None);
             }
         }
 

--- a/code/crates/discovery/src/handlers/peers_management.rs
+++ b/code/crates/discovery/src/handlers/peers_management.rs
@@ -1,5 +1,5 @@
 use libp2p::{swarm::ConnectionId, PeerId, Swarm};
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use crate::{request::RequestData, Discovery, DiscoveryClient, OutboundConnection};
 
@@ -22,7 +22,7 @@ where
             n,
         ) {
             Selection::Exactly(peers) => {
-                info!("Selected exactly {} outbound candidates", peers.len());
+                debug!("Selected exactly {} outbound candidates", peers.len());
                 peers
             }
             Selection::Only(peers) => {
@@ -62,7 +62,7 @@ where
             return;
         }
 
-        info!("Adjusting connections");
+        debug!("Adjusting connections");
 
         self.select_outbound_connections(swarm);
 
@@ -88,15 +88,9 @@ where
             })
             .collect();
 
-        info!(
+        debug!(
             "Connections adjusted by disconnecting {} peers",
             connections_to_close.len(),
-        );
-
-        debug!(
-            "Keeping outbound connections: {:?}, and inbound connections: {:?}",
-            self.outbound_connections.keys(),
-            self.inbound_connections.keys(),
         );
 
         for (peer_id, connection_id) in connections_to_close {
@@ -112,7 +106,7 @@ where
             return;
         }
 
-        info!("Repairing an outbound connection");
+        debug!("Repairing an outbound connection");
 
         // Upgrade any inbound connection to outbound if any is available
         if let Some((peer_id, connection_id)) = self
@@ -123,7 +117,7 @@ where
             .find(|(peer_id, _)| !self.outbound_connections.contains_key(peer_id))
             .map(|(peer_id, connection_id)| (*peer_id, *connection_id))
         {
-            info!("Upgrading connection {connection_id} of peer {peer_id} to outbound connection");
+            debug!("Upgrading connection {connection_id} of peer {peer_id} to outbound connection");
 
             self.inbound_connections.remove(&peer_id);
             self.outbound_connections.insert(
@@ -151,7 +145,7 @@ where
         ) {
             Selection::Exactly(peers) => {
                 if let Some(peer_id) = peers.first() {
-                    info!("Trying to connect to peer {peer_id} to repair outbound connections");
+                    debug!("Trying to connect to peer {peer_id} to repair outbound connections");
                     self.outbound_connections.insert(
                         *peer_id,
                         OutboundConnection {

--- a/code/crates/discovery/src/handlers/selection/selector.rs
+++ b/code/crates/discovery/src/handlers/selection/selector.rs
@@ -14,9 +14,14 @@ where
     C: DiscoveryClient,
 {
     pub(crate) fn get_selector(
+        is_enabled: bool,
         bootstrap_protocol: config::BootstrapProtocol,
         selector: config::Selector,
     ) -> Box<dyn Selector<C>> {
+        if !is_enabled {
+            return Box::new(RandomSelector::new());
+        }
+
         match selector {
             config::Selector::Kademlia => {
                 if bootstrap_protocol != config::BootstrapProtocol::Kademlia {

--- a/code/crates/discovery/src/lib.rs
+++ b/code/crates/discovery/src/lib.rs
@@ -104,7 +104,11 @@ where
             config,
             state,
 
-            selector: Discovery::get_selector(config.bootstrap_protocol, config.selector),
+            selector: Discovery::get_selector(
+                config.enabled,
+                config.bootstrap_protocol,
+                config.selector,
+            ),
 
             bootstrap_nodes: bootstrap_nodes
                 .clone()

--- a/code/crates/discovery/src/lib.rs
+++ b/code/crates/discovery/src/lib.rs
@@ -176,13 +176,13 @@ where
                             },
                     } => match request {
                         behaviour::Request::Peers(peers) => {
-                            debug!(peer_id = %peer, %connection_id, "Received peers request from peer");
+                            debug!(peer_id = %peer, %connection_id, "Received peers request");
 
                             self.handle_peers_request(swarm, peer, channel, peers);
                         }
 
                         behaviour::Request::Connect() => {
-                            debug!(peer_id = %peer, %connection_id, "Received connect request from peer");
+                            debug!(peer_id = %peer, %connection_id, "Received connect request");
 
                             self.handle_connect_request(swarm, channel, peer, connection_id);
                         }
@@ -199,13 +199,13 @@ where
                             },
                     } => match response {
                         behaviour::Response::Peers(peers) => {
-                            debug!(peer_id = %peer, %connection_id, count = peers.len(), "Received peers response from peer");
+                            debug!(%peer, %connection_id, count = peers.len(), "Received peers response");
 
                             self.handle_peers_response(swarm, request_id, peers);
                         }
 
                         behaviour::Response::Connect(accepted) => {
-                            debug!(peer_id = %peer, %connection_id, accepted, "Received connect response from peer");
+                            debug!(%peer, %connection_id, accepted, "Received connect response");
 
                             self.handle_connect_response(
                                 swarm,
@@ -220,10 +220,10 @@ where
                     request_response::Event::OutboundFailure {
                         peer,
                         request_id,
-                        connection_id: _,
+                        connection_id,
                         error,
                     } => {
-                        error!("Outbound request to {peer} failed: {error}");
+                        error!(%peer, %connection_id, "Outbound request to failed: {error}");
 
                         if self.controller.peers_request.is_in_progress(&request_id) {
                             self.handle_failed_peers_request(swarm, request_id);
@@ -231,7 +231,7 @@ where
                             self.handle_failed_connect_request(swarm, request_id);
                         } else {
                             // This should not happen
-                            error!("Unknown outbound request failure to {peer}");
+                            error!(%peer, %connection_id, "Unknown outbound request failure");
                         }
                     }
 

--- a/code/crates/network/src/lib.rs
+++ b/code/crates/network/src/lib.rs
@@ -10,7 +10,7 @@ use libp2p::swarm::{self, SwarmEvent};
 use libp2p::{gossipsub, identify, quic, SwarmBuilder};
 use libp2p_broadcast as broadcast;
 use tokio::sync::{mpsc, oneshot};
-use tracing::{debug, error, error_span, trace, warn, Instrument};
+use tracing::{debug, error, error_span, info, trace, warn, Instrument};
 
 use malachitebft_discovery::{self as discovery};
 use malachitebft_metrics::SharedRegistry;
@@ -202,7 +202,10 @@ pub async fn spawn(
     let state = State::new(discovery);
 
     let peer_id = PeerId::from_libp2p(swarm.local_peer_id());
-    let span = error_span!("network", peer = %peer_id);
+    let span = error_span!("network");
+
+    info!(parent: span.clone(), %peer_id, "Starting network service");
+
     let task_handle =
         tokio::task::spawn(run(config, metrics, state, swarm, rx_ctrl, tx_event).instrument(span));
 

--- a/code/crates/network/test/src/lib.rs
+++ b/code/crates/network/test/src/lib.rs
@@ -155,7 +155,7 @@ impl<const N: usize> Test<N> {
                     TransportProtocol::Quic.multiaddr("127.0.0.1", self.consensus_base_port + *j)
                 })
                 .collect(),
-            discovery: discovery_config.clone(),
+            discovery: discovery_config,
             idle_connection_timeout: Duration::from_secs(60),
             transport: malachitebft_network::TransportProtocol::Quic,
             gossipsub: malachitebft_network::GossipSubConfig::default(),

--- a/code/crates/network/test/src/lib.rs
+++ b/code/crates/network/test/src/lib.rs
@@ -4,9 +4,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use libp2p_identity::PeerId;
 use malachitebft_config::TransportProtocol;
 use malachitebft_metrics::SharedRegistry;
-use malachitebft_network::{
-    spawn, BootstrapProtocol, Config, DiscoveryConfig, Keypair, PeerIdExt, Selector,
-};
+use malachitebft_network::{spawn, Config, DiscoveryConfig, Keypair, PeerIdExt};
 use malachitebft_starknet_host::types::PrivateKey;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use tokio::time::sleep;
@@ -111,6 +109,7 @@ pub struct Test<const N: usize> {
     consensus_base_port: usize,
     spawn_delay: Duration,
     timeout: Duration,
+    discovery_config: DiscoveryConfig,
 }
 
 impl<const N: usize> Test<N> {
@@ -119,6 +118,7 @@ impl<const N: usize> Test<N> {
         expected_peers_sets: [Expected; N],
         spawn_delay: Duration,
         timeout: Duration,
+        discovery_config: DiscoveryConfig,
     ) -> Self {
         Self {
             nodes,
@@ -127,6 +127,7 @@ impl<const N: usize> Test<N> {
             consensus_base_port: rand::thread_rng().gen_range(21000..50000),
             spawn_delay,
             timeout,
+            discovery_config,
         }
     }
 
@@ -143,7 +144,7 @@ impl<const N: usize> Test<N> {
         })
     }
 
-    fn generate_default_configs(&self) -> [Config; N] {
+    fn generate_default_configs(&self, discovery_config: DiscoveryConfig) -> [Config; N] {
         std::array::from_fn(|i| Config {
             listen_addr: TransportProtocol::Quic
                 .multiaddr("127.0.0.1", self.consensus_base_port + i),
@@ -154,12 +155,7 @@ impl<const N: usize> Test<N> {
                     TransportProtocol::Quic.multiaddr("127.0.0.1", self.consensus_base_port + *j)
                 })
                 .collect(),
-            discovery: DiscoveryConfig {
-                enabled: true,
-                bootstrap_protocol: BootstrapProtocol::Full,
-                selector: Selector::Random,
-                ..Default::default()
-            },
+            discovery: discovery_config.clone(),
             idle_connection_timeout: Duration::from_secs(60),
             transport: malachitebft_network::TransportProtocol::Quic,
             gossipsub: malachitebft_network::GossipSubConfig::default(),
@@ -173,7 +169,7 @@ impl<const N: usize> Test<N> {
         init_logging();
         info!("Starting test with {} nodes", N);
 
-        let configs = self.generate_default_configs();
+        let configs = self.generate_default_configs(self.discovery_config);
         debug!("Generated configs");
 
         let mut handles = Vec::with_capacity(N);

--- a/code/crates/network/test/tests/discovery.rs
+++ b/code/crates/network/test/tests/discovery.rs
@@ -1,6 +1,7 @@
 use std::{time::Duration, vec};
 
 use informalsystems_malachitebft_discovery_test::{Expected, Test, TestNode};
+use malachitebft_network::{BootstrapProtocol, DiscoveryConfig, Selector};
 
 // Testing the following circular bootstrap sets graph:
 //     0 <--- 1 <--- 2 <--- 3 <--- 4
@@ -25,6 +26,12 @@ pub async fn circular_graph() {
         ],
         Duration::from_secs(0),
         Duration::from_secs(10),
+        DiscoveryConfig {
+            enabled: true,
+            bootstrap_protocol: BootstrapProtocol::Full,
+            selector: Selector::Random,
+            ..Default::default()
+        },
     );
 
     test.run().await
@@ -50,6 +57,56 @@ pub async fn circular_graph_n() {
         expected.try_into().expect("Expected a Vec of length 100"),
         Duration::from_secs(0),
         Duration::from_secs(10),
+        DiscoveryConfig {
+            enabled: true,
+            bootstrap_protocol: BootstrapProtocol::Full,
+            selector: Selector::Random,
+            ..Default::default()
+        },
+    );
+
+    test.run().await
+}
+
+// Testing correctness when discovery is disabled. Especially, the nodes should
+// not accept more connections than the defined number of inbound peers in the
+// configuration.
+#[tokio::test]
+pub async fn discovery_disabled() {
+    let test = Test::new(
+        [
+            TestNode::correct(0, vec![]),
+            TestNode::correct(1, vec![0]),
+            TestNode::correct(2, vec![0, 1]),
+            TestNode::correct(3, vec![1, 2]),
+            TestNode::correct(4, vec![2, 3]),
+            TestNode::correct(5, vec![3, 4]),
+            TestNode::correct(6, vec![4, 5]),
+            TestNode::correct(7, vec![5, 6]),
+            TestNode::correct(8, vec![6, 7]),
+            TestNode::correct(9, vec![7, 8]),
+            TestNode::correct(10, vec![8, 9]),
+        ],
+        [
+            Expected::Exactly(vec![1, 2]),
+            Expected::Exactly(vec![0, 2]),
+            Expected::Exactly(vec![0, 1]),
+            Expected::Exactly(vec![4, 5]),
+            Expected::Exactly(vec![3, 5]),
+            Expected::Exactly(vec![3, 4]),
+            Expected::Exactly(vec![7, 8]),
+            Expected::Exactly(vec![6, 8]),
+            Expected::Exactly(vec![6, 7]),
+            Expected::Exactly(vec![10]),
+            Expected::Exactly(vec![9]),
+        ],
+        Duration::from_secs(1),
+        Duration::from_secs(10),
+        DiscoveryConfig {
+            enabled: false,
+            num_inbound_peers: 2,
+            ..Default::default()
+        },
     );
 
     test.run().await

--- a/code/crates/starknet/test/src/lib.rs
+++ b/code/crates/starknet/test/src/lib.rs
@@ -152,11 +152,7 @@ impl TestRunner {
                 p2p: P2pConfig {
                     transport,
                     protocol,
-                    discovery: DiscoveryConfig {
-                        enabled: false,
-                        num_inbound_peers: 20,
-                        ..Default::default()
-                    },
+                    discovery: DiscoveryConfig::default(),
                     listen_addr: transport.multiaddr("127.0.0.1", self.consensus_base_port + i),
                     persistent_peers: (0..self.nodes_count)
                         .filter(|j| i != *j)

--- a/code/crates/starknet/test/src/lib.rs
+++ b/code/crates/starknet/test/src/lib.rs
@@ -152,7 +152,11 @@ impl TestRunner {
                 p2p: P2pConfig {
                     transport,
                     protocol,
-                    discovery: DiscoveryConfig::default(),
+                    discovery: DiscoveryConfig {
+                        enabled: false,
+                        num_inbound_peers: 20,
+                        ..Default::default()
+                    },
                     listen_addr: transport.multiaddr("127.0.0.1", self.consensus_base_port + i),
                     persistent_peers: (0..self.nodes_count)
                         .filter(|j| i != *j)


### PR DESCRIPTION
Closes: #886 and #887

Now, when discovery is disabled, all connections are directly persistent. The maximum number of connections allowed is defined in the configuration with the `num_inbound_peers` parameter.
Moreover, the logs in the discovery crate have been reduced to mainly debug verbosity, leaving the most relevant logs as info verbosity.

---

### PR author checklist

#### For all contributors

- [x] Reference GitHub issue
- [x] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [x] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
