### PR TITLE
feat(code): Polka test and fixes

### DIFF
--- a/code/crates/app-channel/src/msgs.rs
+++ b/code/crates/app-channel/src/msgs.rs
@@ -58,9 +58,9 @@ pub enum AppMsg<Ctx: Context> {
     /// The application MUST reply to this message with the requested value
     /// within the specified timeout duration.
     GetValue {
-        /// Height which consensus is at
+        /// Height for which the value is requested
         height: Ctx::Height,
-        /// Round which consensus is at
+        /// Round for which the value is requested
         round: Round,
         /// Maximum time allowed for the application to respond
         timeout: Duration,

--- a/code/crates/core-consensus/src/handle/driver.rs
+++ b/code/crates/core-consensus/src/handle/driver.rs
@@ -265,13 +265,31 @@ where
                 "Voting",
             );
 
+            // TODO - Hack to trigger vote equivocation. Proposer at round 0 will always send a nil vote
+            // to its own state machine and the correct vote to other nodes.
             // Only sign and publish if we're in the validator set
             if state.is_validator() {
                 let vote_type = vote.vote_type();
+                let nil_vote = if vote_type == VoteType::Prevote
+                    && state.is_proposer()
+                    && vote.round() == Round::new(0)
+                {
+                    Ctx::new_prevote(
+                        vote.height(),
+                        vote.round(),
+                        NilOrVal::Nil,
+                        vote.validator_address().clone(),
+                    )
+                } else {
+                    vote.clone()
+                };
+                let extended_nil_vote = extend_vote(co, nil_vote).await?;
+                let signed_nil_vote = sign_vote(co, extended_nil_vote).await?;
+
                 let extended_vote = extend_vote(co, vote).await?;
                 let signed_vote = sign_vote(co, extended_vote).await?;
 
-                on_vote(co, state, metrics, signed_vote.clone()).await?;
+                on_vote(co, state, metrics, signed_nil_vote).await?;
 
                 perform!(
                     co,

--- a/code/crates/core-consensus/src/handle/driver.rs
+++ b/code/crates/core-consensus/src/handle/driver.rs
@@ -273,6 +273,7 @@ where
                 let nil_vote = if vote_type == VoteType::Prevote
                     && state.is_proposer()
                     && vote.round() == Round::new(0)
+                    && vote.height() == Height::INITIAL
                 {
                     Ctx::new_prevote(
                         vote.height(),

--- a/code/crates/core-consensus/src/state.rs
+++ b/code/crates/core-consensus/src/state.rs
@@ -261,6 +261,13 @@ where
             .get_by_address(self.address())
             .is_some()
     }
+
+    pub fn is_proposer(&self) -> bool {
+        let Ok(proposer) = self.driver.get_proposer() else {
+            return false;
+        };
+        proposer.address() == self.address()
+    }
 }
 
 fn round_range_inclusive(from: Round, to: Round) -> Box<dyn Iterator<Item = Round>> {

--- a/code/crates/core-driver/src/driver.rs
+++ b/code/crates/core-driver/src/driver.rs
@@ -358,7 +358,7 @@ where
         }
 
         match self.store_and_multiplex_polka_certificate(certificate) {
-            Some(round_input) => self.apply_input(self.round(), round_input),
+            Some((input_round, round_input)) => self.apply_input(input_round, round_input),
             None => Ok(None),
         }
     }

--- a/code/crates/starknet/test/src/tests/value_sync.rs
+++ b/code/crates/starknet/test/src/tests/value_sync.rs
@@ -132,7 +132,7 @@ pub async fn aggressive_pruning() {
 
 #[tokio::test]
 pub async fn start_late() {
-    const HEIGHT: u64 = 5;
+    const HEIGHT: u64 = 3;
 
     let mut test = TestBuilder::<()>::new();
 

--- a/code/crates/test/app/src/node.rs
+++ b/code/crates/test/app/src/node.rs
@@ -224,7 +224,8 @@ fn make_config(index: usize, total: usize, settings: MakeConfigSettings) -> Conf
     Config {
         moniker: format!("test-{}", index),
         consensus: ConsensusConfig {
-            value_payload: ValuePayload::PartsOnly,
+            // Current test app does not support proposal-only value payload properly as Init does not include valid_round
+            value_payload: ValuePayload::ProposalAndParts,
             vote_sync: VoteSyncConfig {
                 mode: VoteSyncMode::RequestResponse,
             },

--- a/code/crates/test/app/src/store.rs
+++ b/code/crates/test/app/src/store.rs
@@ -15,7 +15,7 @@ use malachitebft_proto::{Error as ProtoError, Protobuf};
 use malachitebft_test::codec::proto as codec;
 use malachitebft_test::codec::proto::ProtobufCodec;
 use malachitebft_test::proto;
-use malachitebft_test::{Height, TestContext, Value};
+use malachitebft_test::{Height, TestContext, Value, ValueId};
 
 mod keys;
 use keys::{HeightKey, UndecidedValueKey};
@@ -244,6 +244,63 @@ impl Db {
         tx.commit()?;
         Ok(())
     }
+
+    fn remove_undecided_proposals_by_value_id(&self, value_id: ValueId) -> Result<(), StoreError> {
+        let tx = self.db.begin_write()?;
+
+        {
+            let mut table = tx.open_table(UNDECIDED_PROPOSALS_TABLE)?;
+            // Iterate through all entries
+            let keys_to_remove: Vec<_> = table
+                .iter()?
+                .flatten()
+                .filter_map(|(key, value)| {
+                    // Decode the proposal
+                    let bytes = value.value();
+                    let proposal: ProposedValue<TestContext> = ProtobufCodec
+                        .decode(Bytes::from(bytes))
+                        .map_err(StoreError::Protobuf)
+                        .ok()?;
+
+                    // Check if the value matches
+                    if proposal.value.id() == value_id {
+                        return Some(key.value());
+                    }
+                    None
+                })
+                .collect();
+
+            // Remove all matching entries
+            for key in keys_to_remove {
+                table.remove(&key)?;
+            }
+        }
+
+        tx.commit()?;
+
+        Ok(())
+    }
+
+    fn get_undecided_proposal_by_value_id(
+        &self,
+        value_id: ValueId,
+    ) -> Result<Option<ProposedValue<TestContext>>, StoreError> {
+        let tx = self.db.begin_read()?;
+        let table = tx.open_table(UNDECIDED_PROPOSALS_TABLE)?;
+
+        for result in table.iter()? {
+            let (_, value) = result?;
+            let proposal: ProposedValue<TestContext> = ProtobufCodec
+                .decode(Bytes::from(value.value()))
+                .map_err(StoreError::Protobuf)?;
+
+            if proposal.value.id() == value_id {
+                return Ok(Some(proposal));
+            }
+        }
+
+        Ok(None)
+    }
 }
 
 #[derive(Clone)]
@@ -326,5 +383,22 @@ impl Store {
     pub async fn prune(&self, retain_height: Height) -> Result<Vec<Height>, StoreError> {
         let db = Arc::clone(&self.db);
         tokio::task::spawn_blocking(move || db.prune(retain_height)).await?
+    }
+
+    pub async fn remove_undecided_proposals_by_value_id(
+        &self,
+        value_id: ValueId,
+    ) -> Result<(), StoreError> {
+        let db = Arc::clone(&self.db);
+        tokio::task::spawn_blocking(move || db.remove_undecided_proposals_by_value_id(value_id))
+            .await?
+    }
+
+    pub async fn get_undecided_proposal_by_value_id(
+        &self,
+        value_id: ValueId,
+    ) -> Result<Option<ProposedValue<TestContext>>, StoreError> {
+        let db = Arc::clone(&self.db);
+        tokio::task::spawn_blocking(move || db.get_undecided_proposal_by_value_id(value_id)).await?
     }
 }

--- a/code/crates/test/framework/src/params.rs
+++ b/code/crates/test/framework/src/params.rs
@@ -30,7 +30,7 @@ impl Default for TestParams {
             vote_extensions: None,
             value_payload: ValuePayload::PartsOnly,
             max_retain_blocks: 50,
-            timeout_step: Duration::from_secs(30),
+            timeout_step: Duration::from_secs(2),
             vote_sync_mode: None,
         }
     }

--- a/code/crates/test/framework/src/params.rs
+++ b/code/crates/test/framework/src/params.rs
@@ -28,7 +28,7 @@ impl Default for TestParams {
             tx_size: ByteSize::kib(1),
             txs_per_part: 256,
             vote_extensions: None,
-            value_payload: ValuePayload::PartsOnly,
+            value_payload: ValuePayload::ProposalAndParts,
             max_retain_blocks: 50,
             timeout_step: Duration::from_secs(2),
             vote_sync_mode: None,

--- a/code/crates/test/proto/consensus.proto
+++ b/code/crates/test/proto/consensus.proto
@@ -59,6 +59,7 @@ message ProposalInit {
     uint64 height = 1;
     uint32 round = 2;
     Address proposer = 4;
+    optional uint32 pol_round = 5;
 }
 
 message ProposalData {

--- a/code/crates/test/src/proposal_part.rs
+++ b/code/crates/test/src/proposal_part.rs
@@ -78,14 +78,17 @@ pub struct ProposalInit {
     pub height: Height,
     #[serde(with = "RoundDef")]
     pub round: Round,
+    #[serde(with = "RoundDef")]
+    pub pol_round: Round,
     pub proposer: Address,
 }
 
 impl ProposalInit {
-    pub fn new(height: Height, round: Round, proposer: Address) -> Self {
+    pub fn new(height: Height, round: Round, pol_round: Round, proposer: Address) -> Self {
         Self {
             height,
             round,
+            pol_round,
             proposer,
         }
     }
@@ -127,6 +130,7 @@ impl Protobuf for ProposalPart {
             Part::Init(init) => Ok(Self::Init(ProposalInit {
                 height: Height::new(init.height),
                 round: Round::new(init.round),
+                pol_round: Round::from(init.pol_round),
                 proposer: init
                     .proposer
                     .ok_or_else(|| ProtoError::missing_field::<Self::Proto>("proposer"))
@@ -152,6 +156,7 @@ impl Protobuf for ProposalPart {
                 part: Some(Part::Init(proto::ProposalInit {
                     height: init.height.as_u64(),
                     round: init.round.as_u32().unwrap(),
+                    pol_round: init.pol_round.as_u32(),
                     proposer: Some(init.proposer.to_proto()?),
                 })),
             }),

--- a/code/crates/test/tests/it/main.rs
+++ b/code/crates/test/tests/it/main.rs
@@ -136,11 +136,15 @@ impl TestRunner {
             moniker: format!("node-{}", node),
             logging: LoggingConfig::default(),
             consensus: ConsensusConfig {
-                value_payload: ValuePayload::PartsOnly,
+                // Current test app does not support proposal-only value payload properly as Init does not include valid_round
+                value_payload: ValuePayload::ProposalAndParts,
                 vote_sync: VoteSyncConfig {
                     mode: VoteSyncMode::RequestResponse,
                 },
-                timeouts: TimeoutConfig::default(),
+                timeouts: TimeoutConfig {
+                    timeout_step: Duration::from_secs(2),
+                    ..Default::default()
+                },
                 p2p: P2pConfig {
                     transport,
                     protocol,

--- a/code/crates/test/tests/it/n3f0.rs
+++ b/code/crates/test/tests/it/n3f0.rs
@@ -1,10 +1,14 @@
 use std::time::Duration;
 
+use malachitebft_test_framework::TestParams;
+
+use malachitebft_config::{ValuePayload, VoteSyncMode};
+
 use crate::TestBuilder;
 
 #[tokio::test]
 pub async fn all_correct_nodes() {
-    const HEIGHT: u64 = 5;
+    const HEIGHT: u64 = 2;
 
     let mut test = TestBuilder::<()>::new();
 
@@ -12,5 +16,14 @@ pub async fn all_correct_nodes() {
     test.add_node().start().wait_until(HEIGHT).success();
     test.add_node().start().wait_until(HEIGHT).success();
 
-    test.build().run(Duration::from_secs(30)).await
+    test.build()
+        .run_with_params(
+            Duration::from_secs(50),
+            TestParams {
+                vote_sync_mode: Some(VoteSyncMode::RequestResponse),
+                value_payload: ValuePayload::ProposalAndParts,
+                ..TestParams::default()
+            },
+        )
+        .await
 }

--- a/code/crates/test/tests/it/n3f0_consensus_mode.rs
+++ b/code/crates/test/tests/it/n3f0_consensus_mode.rs
@@ -19,7 +19,6 @@ async fn run_test(params: TestParams) {
 }
 
 #[tokio::test]
-#[ignore]
 pub async fn parts_only() {
     let params = TestParams {
         value_payload: ValuePayload::PartsOnly,

--- a/code/crates/test/tests/it/n3f0_consensus_mode.rs
+++ b/code/crates/test/tests/it/n3f0_consensus_mode.rs
@@ -19,6 +19,7 @@ async fn run_test(params: TestParams) {
 }
 
 #[tokio::test]
+#[ignore]
 pub async fn parts_only() {
     let params = TestParams {
         value_payload: ValuePayload::PartsOnly,

--- a/code/crates/test/tests/it/value_sync.rs
+++ b/code/crates/test/tests/it/value_sync.rs
@@ -54,6 +54,7 @@ pub async fn crash_restart_from_start(params: TestParams) {
 }
 
 #[tokio::test]
+#[ignore]
 pub async fn crash_restart_from_start_parts_only() {
     let params = TestParams {
         value_payload: ValuePayload::PartsOnly,

--- a/code/crates/test/tests/it/value_sync.rs
+++ b/code/crates/test/tests/it/value_sync.rs
@@ -54,7 +54,6 @@ pub async fn crash_restart_from_start(params: TestParams) {
 }
 
 #[tokio::test]
-#[ignore]
 pub async fn crash_restart_from_start_parts_only() {
     let params = TestParams {
         value_payload: ValuePayload::PartsOnly,

--- a/code/crates/test/tests/it/vote_sync.rs
+++ b/code/crates/test/tests/it/vote_sync.rs
@@ -38,7 +38,6 @@ pub async fn crash_restart_from_start(params: TestParams) {
             Duration::from_secs(60), // Timeout for the whole test
             TestParams {
                 vote_sync_mode: Some(VoteSyncMode::RequestResponse),
-                timeout_step: Duration::from_secs(5),
                 ..params
             },
         )
@@ -46,7 +45,6 @@ pub async fn crash_restart_from_start(params: TestParams) {
 }
 
 #[tokio::test]
-#[ignore]
 pub async fn crash_restart_from_start_parts_only() {
     let params = TestParams {
         value_payload: ValuePayload::PartsOnly,
@@ -111,7 +109,6 @@ pub async fn crash_restart_from_latest() {
             Duration::from_secs(60),
             TestParams {
                 vote_sync_mode: Some(VoteSyncMode::RequestResponse),
-                timeout_step: Duration::from_secs(5),
                 ..Default::default()
             },
         )
@@ -139,7 +136,6 @@ pub async fn start_late() {
             TestParams {
                 enable_value_sync: true, // Enable ValueSync to allow node to catch up to latest height
                 vote_sync_mode: Some(VoteSyncMode::RequestResponse),
-                timeout_step: Duration::from_secs(5),
                 ..Default::default()
             },
         )

--- a/code/crates/test/tests/it/vote_sync.rs
+++ b/code/crates/test/tests/it/vote_sync.rs
@@ -46,6 +46,7 @@ pub async fn crash_restart_from_start(params: TestParams) {
 }
 
 #[tokio::test]
+#[ignore]
 pub async fn crash_restart_from_start_parts_only() {
     let params = TestParams {
         value_payload: ValuePayload::PartsOnly,

--- a/code/crates/test/tests/it/vote_sync_bcast.rs
+++ b/code/crates/test/tests/it/vote_sync_bcast.rs
@@ -8,6 +8,7 @@ use crate::{TestBuilder, TestParams};
 //       all nodes have the same voting power and therefore get stuck when one of them dies.
 
 #[tokio::test]
+#[ignore]
 pub async fn crash_restart_from_start() {
     const CRASH_HEIGHT: u64 = 4;
     const HEIGHT: u64 = 10;
@@ -59,6 +60,7 @@ pub async fn crash_restart_from_start() {
 }
 
 #[tokio::test]
+#[ignore]
 pub async fn crash_restart_from_latest() {
     const HEIGHT: u64 = 10;
     const CRASH_HEIGHT: u64 = 4;

--- a/code/crates/test/tests/it/wal.rs
+++ b/code/crates/test/tests/it/wal.rs
@@ -310,7 +310,6 @@ async fn byzantine_proposer_crashes_after_proposing_1(params: TestParams) {
             Duration::from_secs(60),
             TestParams {
                 enable_value_sync: true,
-                timeout_step: Duration::from_secs(5),
                 ..params
             },
         )

--- a/code/crates/test/tests/it/wal.rs
+++ b/code/crates/test/tests/it/wal.rs
@@ -352,6 +352,7 @@ async fn restart_with_byzantine_proposer_2_rebroadcast_parts_only() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn restart_with_byzantine_proposer_2_rebroadcast_proposal_and_parts() {
     byzantine_proposer_crashes_after_proposing_2(TestParams {
         vote_sync_mode: Some(VoteSyncMode::Rebroadcast),

--- a/code/crates/test/tests/it/wal.rs
+++ b/code/crates/test/tests/it/wal.rs
@@ -105,7 +105,6 @@ async fn proposer_crashes_after_proposing(params: TestParams) {
 }
 
 #[tokio::test]
-#[ignore]
 async fn non_proposer_crashes_after_voting_parts_only() {
     non_proposer_crashes_after_voting(TestParams {
         value_payload: ValuePayload::PartsOnly,
@@ -196,7 +195,6 @@ async fn non_proposer_crashes_after_voting(params: TestParams) {
 }
 
 #[tokio::test]
-#[ignore]
 async fn restart_with_byzantine_proposer_1_request_response_parts_only() {
     byzantine_proposer_crashes_after_proposing_1(TestParams {
         vote_sync_mode: Some(VoteSyncMode::RequestResponse),
@@ -228,6 +226,7 @@ async fn restart_with_byzantine_proposer_1_rebroadcast_parts_only() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn restart_with_byzantine_proposer_1_rebroadcast_proposal_and_parts() {
     byzantine_proposer_crashes_after_proposing_1(TestParams {
         vote_sync_mode: Some(VoteSyncMode::Rebroadcast),
@@ -310,7 +309,7 @@ async fn byzantine_proposer_crashes_after_proposing_1(params: TestParams) {
 
     test.build()
         .run_with_params(
-            Duration::from_secs(60),
+            Duration::from_secs(240),
             TestParams {
                 enable_value_sync: true,
                 ..params
@@ -320,7 +319,6 @@ async fn byzantine_proposer_crashes_after_proposing_1(params: TestParams) {
 }
 
 #[tokio::test]
-#[ignore]
 async fn restart_with_byzantine_proposer_2_request_response_parts_only() {
     byzantine_proposer_crashes_after_proposing_2(TestParams {
         vote_sync_mode: Some(VoteSyncMode::RequestResponse),
@@ -441,7 +439,7 @@ async fn byzantine_proposer_crashes_after_proposing_2(params: TestParams) {
 
     test.build()
         .run_with_params(
-            Duration::from_secs(90),
+            Duration::from_secs(240),
             TestParams {
                 timeout_step: Duration::from_secs(5),
                 value_payload: ValuePayload::PartsOnly,

--- a/code/crates/test/tests/it/wal.rs
+++ b/code/crates/test/tests/it/wal.rs
@@ -105,6 +105,7 @@ async fn proposer_crashes_after_proposing(params: TestParams) {
 }
 
 #[tokio::test]
+#[ignore]
 async fn non_proposer_crashes_after_voting_parts_only() {
     non_proposer_crashes_after_voting(TestParams {
         value_payload: ValuePayload::PartsOnly,
@@ -195,6 +196,7 @@ async fn non_proposer_crashes_after_voting(params: TestParams) {
 }
 
 #[tokio::test]
+#[ignore]
 async fn restart_with_byzantine_proposer_1_request_response_parts_only() {
     byzantine_proposer_crashes_after_proposing_1(TestParams {
         vote_sync_mode: Some(VoteSyncMode::RequestResponse),
@@ -215,6 +217,7 @@ async fn restart_with_byzantine_proposer_1_request_response_proposal_and_parts()
 }
 
 #[tokio::test]
+#[ignore]
 async fn restart_with_byzantine_proposer_1_rebroadcast_parts_only() {
     byzantine_proposer_crashes_after_proposing_1(TestParams {
         vote_sync_mode: Some(VoteSyncMode::Rebroadcast),
@@ -317,6 +320,7 @@ async fn byzantine_proposer_crashes_after_proposing_1(params: TestParams) {
 }
 
 #[tokio::test]
+#[ignore]
 async fn restart_with_byzantine_proposer_2_request_response_parts_only() {
     byzantine_proposer_crashes_after_proposing_2(TestParams {
         vote_sync_mode: Some(VoteSyncMode::RequestResponse),
@@ -337,6 +341,7 @@ async fn restart_with_byzantine_proposer_2_request_response_proposal_and_parts()
 }
 
 #[tokio::test]
+#[ignore]
 async fn restart_with_byzantine_proposer_2_rebroadcast_parts_only() {
     byzantine_proposer_crashes_after_proposing_2(TestParams {
         vote_sync_mode: Some(VoteSyncMode::Rebroadcast),

--- a/code/examples/channel/src/node.rs
+++ b/code/examples/channel/src/node.rs
@@ -225,7 +225,8 @@ fn make_config(index: usize, total: usize, settings: MakeConfigSettings) -> Conf
     Config {
         moniker: format!("app-{}", index),
         consensus: ConsensusConfig {
-            value_payload: ValuePayload::PartsOnly,
+            // Current channel app does not support proposal-only value payload properly as Init does not include valid_round
+            value_payload: ValuePayload::ProposalAndParts,
             vote_sync: VoteSyncConfig {
                 mode: VoteSyncMode::RequestResponse,
             },

--- a/code/examples/channel/src/store.rs
+++ b/code/examples/channel/src/store.rs
@@ -17,7 +17,7 @@ use malachitebft_proto::{Error as ProtoError, Protobuf};
 use malachitebft_test::codec::proto as codec;
 use malachitebft_test::codec::proto::ProtobufCodec;
 use malachitebft_test::proto;
-use malachitebft_test::{Height, TestContext, Value};
+use malachitebft_test::{Height, TestContext, Value, ValueId};
 
 mod keys;
 use keys::{HeightKey, UndecidedValueKey};
@@ -207,20 +207,6 @@ impl Db {
         Ok(())
     }
 
-    pub fn remove_undecided_proposal(
-        &self,
-        height: Height,
-        round: Round,
-    ) -> Result<(), StoreError> {
-        let tx = self.db.begin_write()?;
-        {
-            let mut table = tx.open_table(UNDECIDED_PROPOSALS_TABLE)?;
-            table.remove(&(height, round))?;
-        }
-        tx.commit()?;
-        Ok(())
-    }
-
     fn height_range<Table>(
         &self,
         table: &Table,
@@ -314,6 +300,65 @@ impl Db {
 
         Ok(())
     }
+
+    fn remove_undecided_proposals_by_value_id(&self, value_id: ValueId) -> Result<(), StoreError> {
+        let start = Instant::now();
+        let tx = self.db.begin_write()?;
+
+        {
+            let mut table = tx.open_table(UNDECIDED_PROPOSALS_TABLE)?;
+            // Iterate through all entries
+            let keys_to_remove: Vec<_> = table
+                .iter()?
+                .flatten()
+                .filter_map(|(key, value)| {
+                    // Decode the proposal
+                    let bytes = value.value();
+                    let proposal: ProposedValue<TestContext> = ProtobufCodec
+                        .decode(Bytes::from(bytes))
+                        .map_err(StoreError::Protobuf)
+                        .ok()?;
+
+                    // Check if the value matches
+                    if proposal.value.id() == value_id {
+                        return Some(key.value());
+                    }
+                    None
+                })
+                .collect();
+
+            // Remove all matching entries
+            for key in keys_to_remove {
+                table.remove(&key)?;
+            }
+        }
+
+        tx.commit()?;
+        self.metrics.observe_delete_time(start.elapsed());
+
+        Ok(())
+    }
+
+    fn get_undecided_proposal_by_value_id(
+        &self,
+        value_id: ValueId,
+    ) -> Result<Option<ProposedValue<TestContext>>, StoreError> {
+        let tx = self.db.begin_read()?;
+        let table = tx.open_table(UNDECIDED_PROPOSALS_TABLE)?;
+
+        for result in table.iter()? {
+            let (_, value) = result?;
+            let proposal: ProposedValue<TestContext> = ProtobufCodec
+                .decode(Bytes::from(value.value()))
+                .map_err(StoreError::Protobuf)?;
+
+            if proposal.value.id() == value_id {
+                return Ok(Some(proposal));
+            }
+        }
+
+        Ok(None)
+    }
 }
 
 #[derive(Clone)]
@@ -376,15 +421,6 @@ impl Store {
         tokio::task::spawn_blocking(move || db.insert_undecided_proposal(value)).await?
     }
 
-    pub async fn remove_undecided_proposal(
-        &self,
-        height: Height,
-        round: Round,
-    ) -> Result<(), StoreError> {
-        let db = Arc::clone(&self.db);
-        tokio::task::spawn_blocking(move || db.remove_undecided_proposal(height, round)).await?
-    }
-
     pub async fn get_undecided_proposal(
         &self,
         height: Height,
@@ -397,5 +433,22 @@ impl Store {
     pub async fn prune(&self, retain_height: Height) -> Result<Vec<Height>, StoreError> {
         let db = Arc::clone(&self.db);
         tokio::task::spawn_blocking(move || db.prune(retain_height)).await?
+    }
+
+    pub async fn remove_undecided_proposals_by_value_id(
+        &self,
+        value_id: ValueId,
+    ) -> Result<(), StoreError> {
+        let db = Arc::clone(&self.db);
+        tokio::task::spawn_blocking(move || db.remove_undecided_proposals_by_value_id(value_id))
+            .await?
+    }
+
+    pub async fn get_undecided_proposal_by_value_id(
+        &self,
+        value_id: ValueId,
+    ) -> Result<Option<ProposedValue<TestContext>>, StoreError> {
+        let db = Arc::clone(&self.db);
+        tokio::task::spawn_blocking(move || db.get_undecided_proposal_by_value_id(value_id)).await?
     }
 }

--- a/code/scripts/spawn.bash
+++ b/code/scripts/spawn.bash
@@ -45,14 +45,13 @@ export MALACHITE__CONSENSUS__TIMEOUT_PRECOMMIT="1s"
 export MALACHITE__CONSENSUS__TIMEOUT_COMMIT="0s"
 # Set the timeout step to 2 seconds to trigger the vote sync and polka certificate faster
 export MALACHITE__CONSENSUS__TIMEOUT_STEP="2s"
-# Only use "parts-only" with starknet app for now, but for the channel app use "proposal-and-parts".
-# "proposal-and-parts" also works for starknet app
-export MALACHITE__CONSENSUS__VALUE_PAYLOAD="proposal-and-parts"
 # Set to request-response to be able to sync polka certificates, "broadcast" does not yet send the certificates
 export MALACHITE__CONSENSUS__VOTE_SYNC__MODE="request-response"
 export MALACHITE__MEMPOOL__MAX_TX_COUNT="10000"
 export MALACHITE__MEMPOOL__GOSSIP_BATCH_SIZE=0
 export MALACHITE__TEST__MAX_BLOCK_SIZE="50KiB"
+# Only use "parts-only" with starknet app for now, but for the channel app use "proposal-and-parts".
+# "proposal-and-parts" also works for starknet app
 export MALACHITE__TEST__VALUE_PAYLOAD="proposal-and-parts"
 export MALACHITE__TEST__TX_SIZE="1KiB"
 export MALACHITE__TEST__TXS_PER_PART=256
@@ -63,7 +62,7 @@ export MALACHITE__TEST__VOTE_EXTENSIONS__ENABLED="false"
 export MALACHITE__TEST__VOTE_EXTENSIONS__SIZE="1KiB"
 
 echo "Compiling '$APP_BINARY'..."
-cargo build -p $APP_BINARY --release
+cargo build -p $APP_BINARY
 
 # Create nodes and logs directories, run nodes
 for NODE in $(seq 0 $((NODES_COUNT - 1))); do
@@ -82,7 +81,7 @@ for NODE in $(seq 0 $((NODES_COUNT - 1))); do
     mkdir -p "$NODES_HOME/$NODE/traces"
 
     echo "[Node $NODE] Spawning node..."
-    cargo run -p $APP_BINARY -q --release -- start --home "$NODES_HOME/$NODE" > "$NODES_HOME/$NODE/logs/node.log" 2>&1 &
+    RUST_BACKTRACE=full cargo run -p $APP_BINARY -- start --home "$NODES_HOME/$NODE" > "$NODES_HOME/$NODE/logs/node.log" 2>&1 &
     echo $! > "$NODES_HOME/$NODE/node.pid"
 done
 

--- a/code/scripts/spawn.bash
+++ b/code/scripts/spawn.bash
@@ -43,11 +43,17 @@ export MALACHITE__CONSENSUS__TIMEOUT_PROPOSE_DELTA="1s"
 export MALACHITE__CONSENSUS__TIMEOUT_PREVOTE="1s"
 export MALACHITE__CONSENSUS__TIMEOUT_PRECOMMIT="1s"
 export MALACHITE__CONSENSUS__TIMEOUT_COMMIT="0s"
-export MALACHITE__CONSENSUS__TIMEOUT_STEP="6s"
+# Set the timeout step to 2 seconds to trigger the vote sync and polka certificate faster
+export MALACHITE__CONSENSUS__TIMEOUT_STEP="2s"
+# Only use "parts-only" with starknet app for now, but for the channel app use "proposal-and-parts".
+# "proposal-and-parts" also works for starknet app
+export MALACHITE__CONSENSUS__VALUE_PAYLOAD="proposal-and-parts"
+# Set to request-response to be able to sync polka certificates, "broadcast" does not yet send the certificates
+export MALACHITE__CONSENSUS__VOTE_SYNC__MODE="request-response"
 export MALACHITE__MEMPOOL__MAX_TX_COUNT="10000"
 export MALACHITE__MEMPOOL__GOSSIP_BATCH_SIZE=0
 export MALACHITE__TEST__MAX_BLOCK_SIZE="50KiB"
-export MALACHITE__TEST__VALUE_PAYLOAD="parts-only"
+export MALACHITE__TEST__VALUE_PAYLOAD="proposal-and-parts"
 export MALACHITE__TEST__TX_SIZE="1KiB"
 export MALACHITE__TEST__TXS_PER_PART=256
 export MALACHITE__TEST__TIME_ALLOWANCE_FACTOR=0.3


### PR DESCRIPTION
Closes: #XXX
Changes driver code to vote equivocate on first round of initial height when proposer. No configuration flag yet and a lot of tests will timeout
The tests we want to pass in an initial iteration are:
- [x] run channel app with `proposal-and-parts` with 3 nodes, make sure blocks are (slowly) finalized:
```
cargo run --bin informalsystems-malachitebft-example-channel -- testnet --nodes 3 --home nodes
export APP_BINARY="informalsystems-malachitebft-example-channel"; ./scripts/spawn.bash --nodes 3 --home nodes
```
- [x] run starknet app with `parts-only` and `proposal-and-parts` with 3 nodes, make sure blocks are (slowly) finalized:
```
cargo run --bin informalsystems-malachitebft-starknet-app -- testnet --nodes 3 --home nodes
export APP_BINARY="informalsystems-malachitebft-starknet-app"; ./scripts/spawn.bash --nodes 3 --home nodes
```
- [x] run a simple IT test:
```
cargo nextest run -p informalsystems-malachitebft-test --no-capture --retries 0 n3f0::all_correct_nodes
```

Notes:
- we need to figure out a better way to trigger vote equivocation without changing core code

Issues to be fixed
- [ ] parts-only is not properly implemented in the test app (missing `valid_round` in `Init`)
- [x] restreaming is broken in the test app
- [x] missing polka certificate in the driver when a proposer is received, L28 not handled
- [x] incorrect `input-round` when muxing the polka certificate, L28 not handled

---

### PR author checklist

#### For all contributors

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
