### PR TITLE
docs: Fix incorrect preposition in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Please reach-out if interested, we would love to speak with more teams.
 
 ### Repository
 
-The repository is split in three areas, each covering one of the important areas of this project:
+The repository is split into three areas, each covering one of the important areas of this project:
 
 1. [code](./code): Comprises the Rust implementation of the Tendermint consensus algorithm, split across multiple Rust crates.
 2. [docs](./docs): Comprises Architectural Decision Records (ADRs) and other documentation, such as the 2018 paper describing the core consensus algorithm.


### PR DESCRIPTION
I noticed a small grammar mistake in the documentation: "split in" should be "split into."
This PR fixes it for clarity and correctness.