### PR TITLE
fix(code/core-consensus): Only persist votes in the WAL if they have not yet been seen

### DIFF
--- a/code/crates/core-consensus/src/handle/vote.rs
+++ b/code/crates/core-consensus/src/handle/vote.rs
@@ -75,8 +75,9 @@ where
 
     debug_assert_eq!(consensus_height, vote_height);
 
-    // Only append to WAL and store precommits if we're in the validator set
-    if state.is_validator() {
+    // Only append to WAL and store precommits if we're in the validator set,
+    // and we have not yet seen this vote.
+    if state.is_validator() && !state.driver.votes().has_vote(&signed_vote) {
         // Append the vote to the Write-ahead Log
         perform!(
             co,

--- a/code/crates/core-votekeeper/src/keeper.rs
+++ b/code/crates/core-votekeeper/src/keeper.rs
@@ -96,7 +96,7 @@ where
             }
         }
 
-        // Add the vote to the round
+        // Tally this vote
         self.votes.add_vote(&vote, weight);
 
         // Update the weight of the validator
@@ -198,6 +198,13 @@ where
     /// Return the evidence of equivocation.
     pub fn evidence(&self) -> &EvidenceMap<Ctx> {
         &self.evidence
+    }
+
+    /// Check if we have already seen a vote.
+    pub fn has_vote(&self, vote: &SignedVote<Ctx>) -> bool {
+        self.per_round
+            .get(&vote.round())
+            .is_some_and(|per_round| per_round.received_votes().contains(vote))
     }
 
     /// Apply a vote with a given weight, potentially triggering an output.


### PR DESCRIPTION
Before adding a vote in the WAL, check that we have not yet seen it, ie. that it has not yet been tallied in the vote keeper.

This avoids the situation where a node is stuck, repeatedly asks for votes via vote sync but cannot make progress, and ends up with a lot of duplicate votes in the WAL.

---

### PR author checklist

#### For all contributors

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
