### PR TITLE
feat(code/wal): Add facilities for dumping the WAL entries

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -2117,6 +2117,7 @@ dependencies = [
  "informalsystems-malachitebft-network",
  "informalsystems-malachitebft-peer",
  "informalsystems-malachitebft-sync",
+ "informalsystems-malachitebft-wal",
  "libp2p-identity",
  "ractor",
  "rand 0.8.5",

--- a/code/crates/app/Cargo.toml
+++ b/code/crates/app/Cargo.toml
@@ -22,6 +22,7 @@ malachitebft-metrics.workspace = true
 malachitebft-network.workspace = true
 malachitebft-peer.workspace = true
 malachitebft-sync.workspace = true
+malachitebft-wal.workspace = true
 
 async-trait = { workspace = true }
 derive-where = { workspace = true }

--- a/code/crates/app/src/lib.rs
+++ b/code/crates/app/src/lib.rs
@@ -17,18 +17,9 @@ pub mod events {
     pub use malachitebft_engine::util::events::{RxEvent, TxEvent};
 }
 
-pub mod streaming {
-    pub use malachitebft_engine::util::streaming::*;
-}
-
-pub mod consensus {
-    pub use malachitebft_core_consensus::*;
-}
-
-pub mod metrics {
-    pub use malachitebft_metrics::*;
-}
-
-pub mod config {
-    pub use malachitebft_config::*;
-}
+pub use malachitebft_config as config;
+pub use malachitebft_core_consensus as consensus;
+pub use malachitebft_engine as engine;
+pub use malachitebft_engine::util::streaming;
+pub use malachitebft_metrics as metrics;
+pub use malachitebft_wal as wal;

--- a/code/crates/engine/src/wal.rs
+++ b/code/crates/engine/src/wal.rs
@@ -11,10 +11,12 @@ use malachitebft_metrics::SharedRegistry;
 use malachitebft_wal as wal;
 
 mod entry;
+mod iter;
 mod thread;
 
 pub use entry::WalCodec;
 pub use entry::WalEntry;
+pub use iter::log_entries;
 
 pub type WalRef<Ctx> = ActorRef<Msg<Ctx>>;
 
@@ -53,6 +55,7 @@ pub enum Msg<Ctx: Context> {
     StartedHeight(Ctx::Height, WalReply<Option<Vec<WalEntry<Ctx>>>>),
     Append(Ctx::Height, WalEntry<Ctx>, WalReply<()>),
     Flush(WalReply<()>),
+    Dump,
 }
 
 pub struct Args<Codec> {
@@ -100,6 +103,10 @@ where
 
             Msg::Flush(reply_to) => {
                 self.flush_log(state, reply_to).await?;
+            }
+
+            Msg::Dump => {
+                state.wal_sender.send(self::thread::WalMsg::Dump).await?;
             }
         }
 

--- a/code/crates/engine/src/wal/iter.rs
+++ b/code/crates/engine/src/wal/iter.rs
@@ -1,0 +1,50 @@
+use std::io;
+use std::marker::PhantomData;
+
+use malachitebft_core_types::Context;
+use malachitebft_wal as wal;
+
+use eyre::Result;
+
+use super::{WalCodec, WalEntry};
+
+pub fn log_entries<'a, Ctx, Codec>(
+    log: &'a mut wal::Log,
+    codec: &'a Codec,
+) -> Result<WalIter<'a, Ctx, Codec>>
+where
+    Ctx: Context,
+    Codec: WalCodec<Ctx>,
+{
+    Ok(WalIter {
+        iter: log.iter()?,
+        codec,
+        _marker: PhantomData,
+    })
+}
+
+pub struct WalIter<'a, Ctx, Codec> {
+    iter: wal::LogIter<'a>,
+    codec: &'a Codec,
+    _marker: PhantomData<Ctx>,
+}
+
+impl<Ctx, Codec> Iterator for WalIter<'_, Ctx, Codec>
+where
+    Ctx: Context,
+    Codec: WalCodec<Ctx>,
+{
+    type Item = Result<WalEntry<Ctx>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let entry = self.iter.next()?;
+        match entry {
+            Ok(bytes) => {
+                let buf = io::Cursor::new(bytes);
+                let entry = WalEntry::decode(self.codec, buf);
+                Some(entry.map_err(Into::into))
+            }
+            Err(e) => Some(Err(e.into())),
+        }
+    }
+}

--- a/code/crates/engine/src/wal/thread.rs
+++ b/code/crates/engine/src/wal/thread.rs
@@ -10,6 +10,7 @@ use malachitebft_core_types::{Context, Height};
 use malachitebft_wal as wal;
 
 use super::entry::{WalCodec, WalEntry};
+use super::iter::log_entries;
 
 pub type ReplyTo<T> = oneshot::Sender<Result<T>>;
 
@@ -18,6 +19,7 @@ pub enum WalMsg<Ctx: Context> {
     Append(WalEntry<Ctx>, ReplyTo<()>),
     Flush(ReplyTo<()>),
     Shutdown,
+    Dump,
 }
 
 pub fn spawn<Ctx, Codec>(
@@ -131,6 +133,12 @@ where
             }
         }
 
+        WalMsg::Dump => {
+            if let Err(e) = dump_entries(log, codec) {
+                error!("Failed to dump WAL: {e}");
+            }
+        }
+
         WalMsg::Shutdown => {
             info!("Shutting down WAL thread");
             return Ok(ControlFlow::Break(()));
@@ -179,6 +187,39 @@ where
     } else {
         Ok(entries)
     }
+}
+
+fn dump_entries<'a, Ctx, Codec>(log: &'a mut wal::Log, codec: &'a Codec) -> Result<()>
+where
+    Ctx: Context,
+    Codec: WalCodec<Ctx>,
+{
+    let len = log.len();
+    let mut count = 0;
+
+    info!("WAL Dump");
+    info!("- Entries: {len}");
+    info!("- Size:    {} bytes", log.size_bytes().unwrap_or(0));
+    info!("Entries:");
+
+    for (idx, entry) in log_entries(log, codec)?.enumerate() {
+        count += 1;
+
+        match entry {
+            Ok(entry) => {
+                info!("- #{idx}: {entry:?}");
+            }
+            Err(e) => {
+                error!("- #{idx}: Error decoding WAL entry: {e}");
+            }
+        }
+    }
+
+    if count != len {
+        error!("Expected {len} entries, but found {count} entries");
+    }
+
+    Ok(())
 }
 
 fn span_sequence(sequence: u64, msg: &WalMsg<impl Context>) -> u64 {

--- a/code/crates/starknet/app/src/main.rs
+++ b/code/crates/starknet/app/src/main.rs
@@ -2,6 +2,7 @@ use color_eyre::eyre::Context;
 
 use malachitebft_app::node::Node;
 use malachitebft_config::{LogFormat, LogLevel};
+use malachitebft_starknet_host::codec::ProtobufCodec;
 use malachitebft_starknet_host::node::{ConfigSource, StarknetNode};
 use malachitebft_test_cli::args::{Args, Commands};
 use malachitebft_test_cli::{logging, runtime};
@@ -78,6 +79,13 @@ pub fn main() -> color_eyre::Result<()> {
 
             cmd.run(node, &home_dir)
                 .wrap_err("Failed to run `distributed-testnet` command")
+        }
+
+        Commands::DumpWal(cmd) => {
+            let _guard = logging::init(LogLevel::Info, LogFormat::Plaintext);
+
+            cmd.run(ProtobufCodec)
+                .wrap_err("Failed to run `dump-wal` command")
         }
     }
 }

--- a/code/crates/starknet/host/src/codec.rs
+++ b/code/crates/starknet/host/src/codec.rs
@@ -1,18 +1,16 @@
 use bytes::Bytes;
-use malachitebft_app::streaming::StreamId;
-use malachitebft_starknet_p2p_types::{Felt, FeltExt, Signature};
 use prost::Message;
 
 use malachitebft_codec::Codec;
+use malachitebft_core_consensus::{PeerId, ProposedValue, SignedConsensusMsg};
 use malachitebft_core_types::{
     AggregatedSignature, CommitCertificate, CommitSignature, Round, SignedVote, Validity,
 };
-use malachitebft_engine::util::streaming::{StreamContent, StreamMessage};
+use malachitebft_engine::util::streaming::{StreamContent, StreamId, StreamMessage};
+use malachitebft_starknet_p2p_types::{Felt, FeltExt, Signature};
 use malachitebft_sync::{
     self as sync, ValueRequest, ValueResponse, VoteSetRequest, VoteSetResponse,
 };
-
-use malachitebft_core_consensus::{PeerId, ProposedValue, SignedConsensusMsg};
 
 use crate::proto::{self as proto, Error as ProtoError, Protobuf};
 use crate::types::{self as p2p, Address, BlockHash, Height, MockContext, ProposalPart, Vote};

--- a/code/crates/test/cli/src/args.rs
+++ b/code/crates/test/cli/src/args.rs
@@ -12,6 +12,7 @@ use clap::{Parser, Subcommand};
 use directories::BaseDirs;
 
 use crate::cmd::distributed_testnet::DistributedTestnetCmd;
+use crate::cmd::dump_wal::DumpWalCmd;
 use crate::cmd::init::InitCmd;
 use crate::cmd::start::StartCmd;
 use crate::cmd::testnet::TestnetCmd;
@@ -46,6 +47,9 @@ pub enum Commands {
 
     /// Generate distributed testnet configuration
     DistributedTestnet(DistributedTestnetCmd),
+
+    /// Dump WAL entries
+    DumpWal(DumpWalCmd),
 }
 
 impl Default for Commands {

--- a/code/crates/test/cli/src/cmd/dump_wal.rs
+++ b/code/crates/test/cli/src/cmd/dump_wal.rs
@@ -1,0 +1,51 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use color_eyre::eyre;
+use malachitebft_core_types::Context;
+use tracing::{error, info};
+
+use malachitebft_app::engine::wal::{log_entries, WalCodec};
+use malachitebft_app::wal::Log;
+
+#[derive(Parser, Debug, Clone, Default, PartialEq)]
+pub struct DumpWalCmd {
+    pub wal_file: PathBuf,
+}
+
+impl DumpWalCmd {
+    pub fn run<Ctx, Codec>(&self, codec: Codec) -> eyre::Result<()>
+    where
+        Ctx: Context,
+        Codec: WalCodec<Ctx>,
+    {
+        let mut log = Log::open(&self.wal_file)?;
+
+        let len = log.len();
+        let mut count = 0;
+
+        info!("WAL Dump");
+        info!("- Entries: {len}");
+        info!("- Size:    {} bytes", log.size_bytes().unwrap_or(0));
+        info!("Entries:");
+
+        for (idx, entry) in log_entries(&mut log, &codec)?.enumerate() {
+            count += 1;
+
+            match entry {
+                Ok(entry) => {
+                    info!("- #{idx}: {entry:?}");
+                }
+                Err(e) => {
+                    error!("- #{idx}: Error decoding WAL entry: {e}");
+                }
+            }
+        }
+
+        if count != len {
+            error!("Expected {len} entries, but found {count} entries");
+        }
+
+        Ok(())
+    }
+}

--- a/code/crates/test/cli/src/cmd/mod.rs
+++ b/code/crates/test/cli/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod distributed_testnet;
+pub mod dump_wal;
 pub mod init;
 pub mod start;
 pub mod testnet;

--- a/code/crates/test/src/codec/proto/mod.rs
+++ b/code/crates/test/src/codec/proto/mod.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use prost::Message;
 
-use malachitebft_app::streaming::{StreamContent, StreamId, StreamMessage};
+use malachitebft_app::engine::util::streaming::{StreamContent, StreamId, StreamMessage};
 use malachitebft_codec::Codec;
 use malachitebft_core_consensus::{ProposedValue, SignedConsensusMsg};
 use malachitebft_core_types::{


### PR DESCRIPTION
This PR adds a `dump-wal` command to the test CLI which can dump all entries found in a given WAL file.

It also adds a new `Dump` message to the WAL actor which instructs it to dump the WAL to the console. This message is not used yet but maybe we can come up with a set of conditions which would trigger it?

---

### PR author checklist

#### For all contributors

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
