### PR TITLE
feat(code/test): Middleware for testing

### DIFF
--- a/code/crates/config/src/lib.rs
+++ b/code/crates/config/src/lib.rs
@@ -649,8 +649,6 @@ pub struct TestConfig {
     pub max_retain_blocks: usize,
     #[serde(default)]
     pub vote_extensions: VoteExtensionsConfig,
-    #[serde(default)]
-    pub is_byzantine_proposer: bool,
 }
 
 impl Default for TestConfig {
@@ -663,7 +661,6 @@ impl Default for TestConfig {
             exec_time_per_tx: Duration::from_millis(1),
             max_retain_blocks: 1000,
             vote_extensions: VoteExtensionsConfig::default(),
-            is_byzantine_proposer: false,
         }
     }
 }

--- a/code/crates/core-consensus/src/handle/proposed_value.rs
+++ b/code/crates/core-consensus/src/handle/proposed_value.rs
@@ -39,6 +39,7 @@ where
     // b) In any mode if the proposed value was provided by Sync, where we do net get a Proposal message but only the full value and the certificate
     if state.params.value_payload.parts_only() || origin == ValueOrigin::Sync {
         let proposal = Ctx::new_proposal(
+            &state.ctx,
             proposed_value.height,
             proposed_value.round,
             proposed_value.value.clone(),

--- a/code/crates/core-driver/src/driver.rs
+++ b/code/crates/core-driver/src/driver.rs
@@ -501,7 +501,7 @@ where
         let info = Info::new(input_round, &self.address, proposer.address());
 
         // Apply the input to the round state machine
-        let transition = round_state.apply(&info, input);
+        let transition = round_state.apply(&self.ctx, &info, input);
 
         // Update state
         self.round_state = transition.next_state;

--- a/code/crates/core-state-machine/src/output.rs
+++ b/code/crates/core-state-machine/src/output.rs
@@ -33,33 +33,36 @@ where
 impl<Ctx: Context> Output<Ctx> {
     /// Build a `Proposal` output.
     pub fn proposal(
+        ctx: &Ctx,
         height: Ctx::Height,
         round: Round,
         value: Ctx::Value,
         pol_round: Round,
         address: Ctx::Address,
     ) -> Self {
-        Output::Proposal(Ctx::new_proposal(height, round, value, pol_round, address))
+        Output::Proposal(ctx.new_proposal(height, round, value, pol_round, address))
     }
 
     /// Build a `Vote` output for a prevote.
     pub fn prevote(
+        ctx: &Ctx,
         height: Ctx::Height,
         round: Round,
         value_id: NilOrVal<ValueId<Ctx>>,
         address: Ctx::Address,
     ) -> Self {
-        Output::Vote(Ctx::new_prevote(height, round, value_id, address))
+        Output::Vote(ctx.new_prevote(height, round, value_id, address))
     }
 
     /// Build a `Vote` output for a precommit.
     pub fn precommit(
+        ctx: &Ctx,
         height: Ctx::Height,
         round: Round,
         value_id: NilOrVal<ValueId<Ctx>>,
         address: Ctx::Address,
     ) -> Self {
-        Output::Vote(Ctx::new_precommit(height, round, value_id, address))
+        Output::Vote(ctx.new_precommit(height, round, value_id, address))
     }
 
     /// Build a `ScheduleTimeout` output.

--- a/code/crates/core-state-machine/src/state.rs
+++ b/code/crates/core-state-machine/src/state.rs
@@ -130,8 +130,8 @@ where
     }
 
     /// Apply the given input to the current state, triggering a transition.
-    pub fn apply(self, data: &Info<Ctx>, input: Input<Ctx>) -> Transition<Ctx> {
-        crate::state_machine::apply(self, data, input)
+    pub fn apply(self, ctx: &Ctx, data: &Info<Ctx>, input: Input<Ctx>) -> Transition<Ctx> {
+        crate::state_machine::apply(ctx, self, data, input)
     }
 
     /// Return the traces logged during execution.

--- a/code/crates/core-types/src/context.rs
+++ b/code/crates/core-types/src/context.rs
@@ -50,6 +50,7 @@ where
 
     /// Build a new proposal for the given value at the given height, round and POL round.
     fn new_proposal(
+        &self,
         height: Self::Height,
         round: Round,
         value: Self::Value,
@@ -60,6 +61,7 @@ where
     /// Build a new prevote vote by the validator with the given address,
     /// for the value identified by the given value id, at the given round.
     fn new_prevote(
+        &self,
         height: Self::Height,
         round: Round,
         value_id: NilOrVal<ValueId<Self>>,
@@ -69,6 +71,7 @@ where
     /// Build a new precommit vote by the validator with the given address,
     /// for the value identified by the given value id, at the given round.
     fn new_precommit(
+        &self,
         height: Self::Height,
         round: Round,
         value_id: NilOrVal<ValueId<Self>>,

--- a/code/crates/starknet/p2p-types/src/context.rs
+++ b/code/crates/starknet/p2p-types/src/context.rs
@@ -51,6 +51,7 @@ impl Context for MockContext {
     }
 
     fn new_proposal(
+        &self,
         height: Height,
         round: Round,
         value_id: Hash,
@@ -61,6 +62,7 @@ impl Context for MockContext {
     }
 
     fn new_prevote(
+        &self,
         height: Height,
         round: Round,
         value_id: NilOrVal<Hash>,
@@ -70,6 +72,7 @@ impl Context for MockContext {
     }
 
     fn new_precommit(
+        &self,
         height: Height,
         round: Round,
         value_id: NilOrVal<Hash>,

--- a/code/crates/test/Cargo.toml
+++ b/code/crates/test/Cargo.toml
@@ -17,10 +17,7 @@ malachitebft-core-types = { workspace = true }
 malachitebft-config = { workspace = true }
 malachitebft-core-consensus = { workspace = true }
 malachitebft-proto = { workspace = true }
-malachitebft-signing-ed25519 = { workspace = true, features = [
-  "rand",
-  "serde",
-] }
+malachitebft-signing-ed25519 = { workspace = true, features = ["rand", "serde"] }
 malachitebft-sync = { workspace = true }
 
 async-trait = { workspace = true }

--- a/code/crates/test/app/src/app.rs
+++ b/code/crates/test/app/src/app.rs
@@ -110,12 +110,7 @@ pub async fn run(
                     None => {
                         // If we have not previously built a value for that very same height and round,
                         // we need to create a new value to propose and send it back to consensus.
-                        let proposal = state.propose_value(height, round).await?;
-                        error!(
-                            "XXX Building a new value to propose {:}",
-                            proposal.value.id()
-                        );
-                        proposal
+                        state.propose_value(height, round).await?
                     }
                 };
 

--- a/code/crates/test/app/src/app.rs
+++ b/code/crates/test/app/src/app.rs
@@ -88,8 +88,7 @@ pub async fn run(
                 // then we would need to respect the timeout and stop at a certain point.
 
                 info!(%height, %round, "Consensus is requesting a value to propose");
-
-                dbg!(state.ctx.middleware());
+                tracing::debug!(%height, %round, "Middleware: {:?}", state.ctx.middleware());
 
                 // Here it is important that, if we have previously built a value for this height and round,
                 // we send back the very same value.

--- a/code/crates/test/app/src/app.rs
+++ b/code/crates/test/app/src/app.rs
@@ -89,28 +89,32 @@ pub async fn run(
 
                 info!(%height, %round, "Consensus is requesting a value to propose");
 
+                dbg!(state.ctx.middleware());
+
                 // Here it is important that, if we have previously built a value for this height and round,
                 // we send back the very same value.
                 // However, for testing purposes a node may be configured to be a byzantine proposer.
                 // In that case, we will not send back the previously built value but a new one.
                 let proposal = match state.get_previously_built_value(height, round).await? {
-                    Some(proposal) => {
-                        if state.config.test.is_byzantine_proposer {
-                            let new_proposal = state.propose_value(height, round).await?;
-                            error!(
-                                "XXX Not Re-using previously built value {:} but a new one {:}",
-                                proposal.value.id(),
-                                new_proposal.value.id()
-                            );
-                            new_proposal
-                        } else {
-                            proposal
-                        }
+                    Some(mut proposal) => {
+                        state
+                            .ctx
+                            .middleware()
+                            .on_propose_value(&state.ctx, &mut proposal, true);
+
+                        proposal
                     }
                     None => {
                         // If we have not previously built a value for that very same height and round,
                         // we need to create a new value to propose and send it back to consensus.
-                        state.propose_value(height, round).await?
+                        let mut proposal = state.propose_value(height, round).await?;
+
+                        state
+                            .ctx
+                            .middleware()
+                            .on_propose_value(&state.ctx, &mut proposal, false);
+
+                        proposal
                     }
                 };
 

--- a/code/crates/test/framework/src/logging.rs
+++ b/code/crates/test/framework/src/logging.rs
@@ -2,16 +2,29 @@ pub fn init_logging() {
     use tracing_subscriber::util::SubscriberInitExt;
     use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
-    let crate_name = env!("CARGO_CRATE_NAME");
     let debug_vars = &[("ACTIONS_RUNNER_DEBUG", "true"), ("MALACHITE_DEBUG", "1")];
     let enable_debug = debug_vars
         .iter()
         .any(|(k, v)| std::env::var(k).as_deref() == Ok(v));
 
-    let trace_level = if enable_debug { "trace" } else { "info" };
-    let directive = format!(
-        "{crate_name}=debug,informalsystems_malachitebft={trace_level},informalsystems_malachitebft_discovery=error,libp2p=warn,ractor=warn"
-    );
+    let trace_level = if enable_debug { "debug" } else { "info" };
+
+    let directives = &[
+        ("informalsystems_malachitebft", trace_level),
+        (env!("CARGO_CRATE_NAME"), "debug"),
+        ("it", "debug"), // Name of the integration test crate
+        ("informalsystems_malachitebft_test", "debug"),
+        ("informalsystems_malachitebft_test_app", "debug"),
+        ("informalsystems_malachitebft_discovery", "error"),
+        ("libp2p", "warn"),
+        ("ractor", "warn"),
+    ];
+
+    let directive = directives
+        .iter()
+        .map(|(target, level)| format!("{target}={level}"))
+        .collect::<Vec<_>>()
+        .join(",");
 
     let filter = EnvFilter::builder().parse(directive).unwrap();
 

--- a/code/crates/test/framework/src/node.rs
+++ b/code/crates/test/framework/src/node.rs
@@ -44,7 +44,6 @@ where
     pub voting_power: VotingPower,
     pub start_height: Ctx::Height,
     pub start_delay: Duration,
-    pub is_byzantine_proposer: bool,
     pub steps: Vec<Step<Ctx, State>>,
     pub state: State,
     pub middleware: Arc<dyn Middleware>,
@@ -67,7 +66,6 @@ where
             voting_power: 1,
             start_height: Ctx::Height::INITIAL,
             start_delay: Duration::from_secs(0),
-            is_byzantine_proposer: false,
             steps: vec![],
             state,
             middleware: Arc::new(DefaultMiddleware),
@@ -86,11 +84,6 @@ where
 
     pub fn with_voting_power(&mut self, power: VotingPower) -> &mut Self {
         self.voting_power = power;
-        self
-    }
-
-    pub fn byzantine_proposer(&mut self) -> &mut Self {
-        self.is_byzantine_proposer = true;
         self
     }
 

--- a/code/crates/test/framework/src/node.rs
+++ b/code/crates/test/framework/src/node.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use eyre::bail;
@@ -6,6 +7,7 @@ use tracing::info;
 use malachitebft_core_consensus::{LocallyProposedValue, SignedConsensusMsg};
 use malachitebft_core_types::{Context, Height, SignedVote, Vote, VotingPower};
 use malachitebft_engine::util::events::Event;
+use malachitebft_test::middleware::{DefaultMiddleware, Middleware};
 
 use crate::Expected;
 
@@ -45,6 +47,7 @@ where
     pub is_byzantine_proposer: bool,
     pub steps: Vec<Step<Ctx, State>>,
     pub state: State,
+    pub middleware: Arc<dyn Middleware>,
 }
 
 impl<Ctx, State> TestNode<Ctx, State>
@@ -67,7 +70,13 @@ where
             is_byzantine_proposer: false,
             steps: vec![],
             state,
+            middleware: Arc::new(DefaultMiddleware),
         }
+    }
+
+    pub fn with_middleware(&mut self, middleware: impl Middleware + 'static) -> &mut Self {
+        self.middleware = Arc::new(middleware);
+        self
     }
 
     pub fn with_state(&mut self, state: State) -> &mut Self {

--- a/code/crates/test/mbt/src/tests/consensus/runner.rs
+++ b/code/crates/test/mbt/src/tests/consensus/runner.rs
@@ -18,6 +18,7 @@ use super::utils::{
 };
 
 pub struct ConsensusRunner {
+    pub ctx: TestContext,
     pub address_map: BTreeMap<String, Address>,
     pub last_state: Option<State>,
     pub skip_step: bool,
@@ -26,6 +27,7 @@ pub struct ConsensusRunner {
 impl ConsensusRunner {
     pub fn new(address_map: BTreeMap<String, Address>) -> Self {
         Self {
+            ctx: TestContext::new(),
             address_map,
             last_state: None,
             skip_step: false,
@@ -99,7 +101,7 @@ impl ItfRunner for ConsensusRunner {
             ModelInput::Proposal(round, value) => {
                 let input_round = Round::from(*round);
                 let data = Info::new(input_round, address, some_other_node);
-                let proposal = TestContext::new_proposal(
+                let proposal = self.ctx.new_proposal(
                     actual.height,
                     input_round,
                     value_from_model(value).unwrap(),
@@ -111,7 +113,7 @@ impl ItfRunner for ConsensusRunner {
 
             ModelInput::ProposalAndPolkaPreviousAndValid(value, valid_round) => {
                 let data = Info::new(actual.round, address, some_other_node);
-                let proposal = TestContext::new_proposal(
+                let proposal = self.ctx.new_proposal(
                     actual.height,
                     actual.round,
                     value_from_model(value).unwrap(),
@@ -123,7 +125,7 @@ impl ItfRunner for ConsensusRunner {
 
             ModelInput::ProposalAndPolkaAndValid(value) => {
                 let data = Info::new(actual.round, address, some_other_node);
-                let proposal = TestContext::new_proposal(
+                let proposal = self.ctx.new_proposal(
                     actual.height,
                     actual.round,
                     value_from_model(value).unwrap(),
@@ -135,7 +137,7 @@ impl ItfRunner for ConsensusRunner {
 
             ModelInput::ProposalAndPolkaAndInvalid(value) => {
                 let data = Info::new(actual.round, address, some_other_node);
-                let proposal = TestContext::new_proposal(
+                let proposal = self.ctx.new_proposal(
                     actual.height,
                     actual.round,
                     value_from_model(value).unwrap(),
@@ -148,7 +150,7 @@ impl ItfRunner for ConsensusRunner {
             ModelInput::ProposalAndCommitAndValid(round, value) => {
                 let input_round = Round::from(*round);
                 let data = Info::new(input_round, address, some_other_node);
-                let proposal = TestContext::new_proposal(
+                let proposal = self.ctx.new_proposal(
                     actual.height,
                     input_round,
                     value_from_string(value).unwrap(),
@@ -203,7 +205,7 @@ impl ItfRunner for ConsensusRunner {
         };
 
         let round_state = core::mem::take(actual);
-        let transition = round_state.apply(&data, input);
+        let transition = round_state.apply(&self.ctx, &data, input);
 
         println!("🔹 transition: next state={:?}", transition.next_state);
         println!("🔹 transition: output={:?}", transition.output);

--- a/code/crates/test/src/context.rs
+++ b/code/crates/test/src/context.rs
@@ -1,9 +1,13 @@
+use std::sync::Arc;
+
 use bytes::Bytes;
 
 use malachitebft_core_types::{Context, NilOrVal, Round, ValidatorSet as _};
 
 use crate::address::*;
 use crate::height::*;
+use crate::middleware;
+use crate::middleware::Middleware;
 use crate::proposal::*;
 use crate::proposal_part::*;
 use crate::signing::*;
@@ -11,12 +15,28 @@ use crate::validator_set::*;
 use crate::value::*;
 use crate::vote::*;
 
-#[derive(Copy, Clone, Debug, Default)]
-pub struct TestContext;
+#[derive(Clone, Debug)]
+pub struct TestContext {
+    middleware: Arc<dyn Middleware>,
+}
+
+impl Default for TestContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl TestContext {
     pub fn new() -> Self {
-        Self
+        Self::with_middleware(Arc::new(middleware::DefaultMiddleware))
+    }
+
+    pub fn with_middleware(middleware: Arc<dyn Middleware>) -> Self {
+        Self { middleware }
+    }
+
+    pub fn middleware(&self) -> &Arc<dyn Middleware> {
+        &self.middleware
     }
 
     pub fn select_proposer<'a>(
@@ -63,30 +83,36 @@ impl Context for TestContext {
     }
 
     fn new_proposal(
+        &self,
         height: Height,
         round: Round,
         value: Value,
         pol_round: Round,
         address: Address,
     ) -> Proposal {
-        Proposal::new(height, round, value, pol_round, address)
+        self.middleware
+            .new_proposal(self, height, round, value, pol_round, address)
     }
 
     fn new_prevote(
+        &self,
         height: Height,
         round: Round,
         value_id: NilOrVal<ValueId>,
         address: Address,
     ) -> Vote {
-        Vote::new_prevote(height, round, value_id, address)
+        self.middleware
+            .new_prevote(self, height, round, value_id, address)
     }
 
     fn new_precommit(
+        &self,
         height: Height,
         round: Round,
         value_id: NilOrVal<ValueId>,
         address: Address,
     ) -> Vote {
-        Vote::new_precommit(height, round, value_id, address)
+        self.middleware
+            .new_precommit(self, height, round, value_id, address)
     }
 }

--- a/code/crates/test/src/lib.rs
+++ b/code/crates/test/src/lib.rs
@@ -14,6 +14,7 @@ mod value;
 mod vote;
 
 pub mod codec;
+pub mod middleware;
 pub mod proposer_selector;
 pub mod proto;
 pub mod utils;

--- a/code/crates/test/src/middleware.rs
+++ b/code/crates/test/src/middleware.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 
+use malachitebft_core_consensus::LocallyProposedValue;
 use malachitebft_core_types::{NilOrVal, Round};
 
 use crate::{Address, Height, Proposal, TestContext, Value, ValueId, Vote};
@@ -37,6 +38,14 @@ pub trait Middleware: fmt::Debug + Send + Sync {
         address: Address,
     ) -> Vote {
         Vote::new_precommit(height, round, value_id, address)
+    }
+
+    fn on_propose_value(
+        &self,
+        _ctx: &TestContext,
+        _proposed_value: &mut LocallyProposedValue<TestContext>,
+        _reproposal: bool,
+    ) {
     }
 }
 

--- a/code/crates/test/src/middleware.rs
+++ b/code/crates/test/src/middleware.rs
@@ -1,0 +1,46 @@
+use core::fmt;
+
+use malachitebft_core_types::{NilOrVal, Round};
+
+use crate::{Address, Height, Proposal, TestContext, Value, ValueId, Vote};
+
+pub trait Middleware: fmt::Debug + Send + Sync {
+    fn new_proposal(
+        &self,
+        _ctx: &TestContext,
+        height: Height,
+        round: Round,
+        value: Value,
+        pol_round: Round,
+        address: Address,
+    ) -> Proposal {
+        Proposal::new(height, round, value, pol_round, address)
+    }
+
+    fn new_prevote(
+        &self,
+        _ctx: &TestContext,
+        height: Height,
+        round: Round,
+        value_id: NilOrVal<ValueId>,
+        address: Address,
+    ) -> Vote {
+        Vote::new_prevote(height, round, value_id, address)
+    }
+
+    fn new_precommit(
+        &self,
+        _ctx: &TestContext,
+        height: Height,
+        round: Round,
+        value_id: NilOrVal<ValueId>,
+        address: Address,
+    ) -> Vote {
+        Vote::new_precommit(height, round, value_id, address)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct DefaultMiddleware;
+
+impl Middleware for DefaultMiddleware {}

--- a/code/crates/test/tests/it/main.rs
+++ b/code/crates/test/tests/it/main.rs
@@ -11,9 +11,11 @@ mod wal;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use informalsystems_malachitebft_test::middleware::Middleware;
 use malachitebft_test_app::config::Config;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -58,6 +60,7 @@ fn temp_dir(id: NodeId) -> PathBuf {
 pub struct NodeInfo {
     start_height: Height,
     home_dir: PathBuf,
+    middleware: Arc<dyn Middleware>,
     is_byzantine_proposer: bool,
 }
 
@@ -79,6 +82,7 @@ impl NodeRunner<TestContext> for TestRunner {
                     NodeInfo {
                         start_height: node.start_height,
                         home_dir: temp_dir(node.id),
+                        middleware: Arc::clone(&node.middleware),
                         is_byzantine_proposer: node.is_byzantine_proposer,
                     },
                 )
@@ -104,6 +108,7 @@ impl NodeRunner<TestContext> for TestRunner {
             validator_set: self.validator_set.clone(),
             private_key: self.private_keys[&id].clone(),
             start_height: Some(self.nodes_info[&id].start_height),
+            middleware: Some(Arc::clone(&self.nodes_info[&id].middleware)),
         };
 
         app.start().await

--- a/code/crates/test/tests/it/main.rs
+++ b/code/crates/test/tests/it/main.rs
@@ -61,7 +61,6 @@ pub struct NodeInfo {
     start_height: Height,
     home_dir: PathBuf,
     middleware: Arc<dyn Middleware>,
-    is_byzantine_proposer: bool,
 }
 
 #[async_trait]
@@ -83,7 +82,6 @@ impl NodeRunner<TestContext> for TestRunner {
                         start_height: node.start_height,
                         home_dir: temp_dir(node.id),
                         middleware: Arc::clone(&node.middleware),
-                        is_byzantine_proposer: node.is_byzantine_proposer,
                     },
                 )
             })
@@ -173,10 +171,7 @@ impl TestRunner {
                     .unwrap(),
             },
             runtime: RuntimeConfig::single_threaded(),
-            test: TestConfig {
-                is_byzantine_proposer: self.nodes_info[&node].is_byzantine_proposer,
-                ..TestConfig::default()
-            },
+            test: TestConfig::default(),
         }
     }
 }

--- a/code/crates/test/tests/it/wal.rs
+++ b/code/crates/test/tests/it/wal.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use eyre::bail;
 use tracing::info;
 
-use informalsystems_malachitebft_test as malachitebft_test;
+use informalsystems_malachitebft_test::{self as malachitebft_test};
 
 use malachitebft_config::{ValuePayload, VoteSyncMode};
 use malachitebft_core_consensus::LocallyProposedValue;

--- a/code/crates/test/tests/it/wal.rs
+++ b/code/crates/test/tests/it/wal.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use eyre::bail;
+use informalsystems_malachitebft_test::middleware::Middleware;
 use tracing::info;
 
 use informalsystems_malachitebft_test::{self as malachitebft_test};
@@ -268,7 +269,7 @@ async fn byzantine_proposer_crashes_after_proposing_1(params: TestParams) {
 
     test.add_node()
         .with_voting_power(10)
-        .byzantine_proposer()
+        .with_middleware(ByzantineProposer)
         .start()
         .wait_until(CRASH_HEIGHT)
         // Wait until this node proposes a value
@@ -397,7 +398,7 @@ async fn byzantine_proposer_crashes_after_proposing_2(params: TestParams) {
 
     test.add_node()
         .with_voting_power(10)
-        .byzantine_proposer()
+        .with_middleware(ByzantineProposer)
         .start()
         .wait_until(CRASH_HEIGHT)
         // Wait until this node proposes a value
@@ -449,4 +450,40 @@ async fn byzantine_proposer_crashes_after_proposing_2(params: TestParams) {
             },
         )
         .await
+}
+
+#[derive(Copy, Clone, Debug)]
+struct ByzantineProposer;
+
+impl Middleware for ByzantineProposer {
+    fn on_propose_value(
+        &self,
+        _ctx: &TestContext,
+        proposal: &mut LocallyProposedValue<TestContext>,
+        reproposal: bool,
+    ) {
+        if !reproposal {
+            // Do not change the value if it is the first time we propose it
+            return;
+        }
+
+        use informalsystems_malachitebft_test::Value;
+        use rand::Rng;
+
+        // Make up a new value that is different from the one we are supposed to propose
+        let new_value = loop {
+            let new_value = Value::new(rand::thread_rng().gen_range(100..=100000));
+            if new_value != proposal.value {
+                break new_value;
+            }
+        };
+
+        tracing::error!(
+            "XXX Not re-using previously built value {:} but a new one {:}",
+            proposal.value.id(),
+            new_value.id()
+        );
+
+        proposal.value = new_value;
+    }
 }

--- a/code/crates/test/tests/it/wal.rs
+++ b/code/crates/test/tests/it/wal.rs
@@ -462,13 +462,18 @@ impl Middleware for ByzantineProposer {
         proposal: &mut LocallyProposedValue<TestContext>,
         reproposal: bool,
     ) {
+        use informalsystems_malachitebft_test::Value;
+        use rand::Rng;
+
         if !reproposal {
+            tracing::warn!(
+                "ByzantineProposer: First time proposing value {:}",
+                proposal.value.id()
+            );
+
             // Do not change the value if it is the first time we propose it
             return;
         }
-
-        use informalsystems_malachitebft_test::Value;
-        use rand::Rng;
 
         // Make up a new value that is different from the one we are supposed to propose
         let new_value = loop {
@@ -478,8 +483,8 @@ impl Middleware for ByzantineProposer {
             }
         };
 
-        tracing::error!(
-            "XXX Not re-using previously built value {:} but a new one {:}",
+        tracing::warn!(
+            "ByzantineProposer: Not re-using previously built value {:} but a new one {:}",
             proposal.value.id(),
             new_value.id()
         );

--- a/code/examples/channel/src/node.rs
+++ b/code/examples/channel/src/node.rs
@@ -127,7 +127,7 @@ impl Node for App {
         let codec = ProtobufCodec;
 
         let (mut channels, engine_handle) = malachitebft_app_channel::start_engine(
-            ctx,
+            ctx.clone(),
             codec,
             self.clone(),
             config.clone(),


### PR DESCRIPTION
Add a `Middleware` to the `TestContext` to override how votes and proposals are built, allowing us to change what a node votes or proposes on a per-test basis.

This was extracted from https://github.com/informalsystems/malachite/pull/896 to make it easier to review that PR.

---

* Make `new_prevote`, `new_precommit` and `new_proposal` methods of `Context` instead of static functions

* Stuff middleware in the `TestContext` instead of static variable

* Remove unused dependency

* Add way to access middleware from TestContext

---

### PR author checklist

#### For all contributors

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
