### PR TITLE
feat(code): Add the capability to re-run consensus for a given height

### DIFF
--- a/code/crates/app-channel/src/msgs.rs
+++ b/code/crates/app-channel/src/msgs.rs
@@ -213,6 +213,9 @@ pub enum ConsensusMsg<Ctx: Context> {
 
     /// Previousuly received value proposed by a validator
     ReceivedProposedValue(ProposedValue<Ctx>, ValueOrigin),
+
+    /// Instructs consensus to restart at a given height with the given validator set.
+    RestartHeight(Ctx::Height, Ctx::ValidatorSet),
 }
 
 impl<Ctx: Context> From<ConsensusMsg<Ctx>> for ConsensusActorMsg<Ctx> {
@@ -223,6 +226,9 @@ impl<Ctx: Context> From<ConsensusMsg<Ctx>> for ConsensusActorMsg<Ctx> {
             }
             ConsensusMsg::ReceivedProposedValue(value, origin) => {
                 ConsensusActorMsg::ReceivedProposedValue(value, origin)
+            }
+            ConsensusMsg::RestartHeight(height, validator_set) => {
+                ConsensusActorMsg::RestartHeight(height, validator_set)
             }
         }
     }

--- a/code/crates/test/app/src/app.rs
+++ b/code/crates/test/app/src/app.rs
@@ -183,25 +183,39 @@ pub async fn run(
                     height = %certificate.height,
                     round = %certificate.round,
                     value = %certificate.value_id,
-                    "Consensus has decided on value"
+                    "Consensus has decided on value, committing..."
                 );
                 assert!(!certificate.aggregated_signature.signatures.is_empty());
 
                 // When that happens, we store the decided value in our store
-                state.commit(certificate).await?;
-
-                sleep(Duration::from_millis(500)).await;
-
-                // And then we instruct consensus to start the next height
-                if reply
-                    .send(ConsensusMsg::StartHeight(
-                        state.current_height,
-                        genesis.validator_set.clone(),
-                    ))
-                    .is_err()
-                {
-                    error!("Failed to send Decided reply");
+                match state.commit(certificate).await {
+                    Ok(_) => {
+                        // And then we instruct consensus to start the next height
+                        if reply
+                            .send(ConsensusMsg::StartHeight(
+                                state.current_height,
+                                genesis.validator_set.clone(),
+                            ))
+                            .is_err()
+                        {
+                            error!("Failed to send StartHeight reply");
+                        }
+                    }
+                    Err(_) => {
+                        // Commit failed, restart the height
+                        error!("Commit failed, restarting height {}", state.current_height);
+                        if reply
+                            .send(ConsensusMsg::RestartHeight(
+                                state.current_height,
+                                genesis.validator_set.clone(),
+                            ))
+                            .is_err()
+                        {
+                            error!("Failed to send RestartHeight reply");
+                        }
+                    }
                 }
+                sleep(Duration::from_millis(500)).await;
             }
 
             // It may happen that our node is lagging behind its peers. In that case,

--- a/code/examples/channel/src/state.rs
+++ b/code/examples/channel/src/state.rs
@@ -211,25 +211,36 @@ impl State {
                 "Trying to commit a value with value id {value_id} at height {height} and round {round} for which there is no proposal"
             ));
         };
-
-        self.store
-            .store_decided_value(&certificate, proposal.value)
-            .await?;
-
-        // Remove all proposals with the given value id.
         self.store
             .remove_undecided_proposals_by_value_id(value_id)
             .await?;
 
-        // Prune the store, keep the last HISTORY_LENGTH values
-        let retain_height = Height::new(height.as_u64().saturating_sub(HISTORY_LENGTH));
-        self.store.prune(retain_height).await?;
+        // TODO - undo before merge
+        // Create a random reset height
+        let reset_height = 10 + self.rng.gen_range(0..50); // Spreads resets between height 10-59
+        let reset = height.as_u64() == reset_height;
 
-        // Move to next height
-        self.current_height = self.current_height.increment();
+        if !reset {
+            self.store
+                .store_decided_value(&certificate, proposal.value)
+                .await?;
+
+            // Prune the store, keep the last HISTORY_LENGTH values
+            let retain_height = Height::new(height.as_u64().saturating_sub(HISTORY_LENGTH));
+            self.store.prune(retain_height).await?;
+
+            // Move to next height
+            self.current_height = self.current_height.increment();
+        }
+
         self.current_round = Round::new(0);
 
-        Ok(())
+        if reset {
+            error!("Resetting at height {reset_height}");
+            Err(eyre!("Resetting at height {reset_height}"))
+        } else {
+            Ok(())
+        }
     }
 
     /// Retrieves a previously built proposal value for the given height


### PR DESCRIPTION
Closes: #893

Added new `RestartHeight` message, similar with `StartHeight` with the exception that the WAL is reset and not replayed.
Should be able to use the same for starknet reset protocol.

---

### PR author checklist

#### For all contributors

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
