### PR TITLE
feat(code/sync): Include both tip and sync height in sync status

### DIFF
--- a/code/crates/engine/src/network.rs
+++ b/code/crates/engine/src/network.rs
@@ -126,14 +126,20 @@ pub enum State<Ctx: Context> {
 
 #[derive_where(Clone, Debug, PartialEq, Eq)]
 pub struct Status<Ctx: Context> {
-    pub height: Ctx::Height,
+    pub tip_height: Ctx::Height,
+    pub sync_height: Ctx::Height,
     pub history_min_height: Ctx::Height,
 }
 
 impl<Ctx: Context> Status<Ctx> {
-    pub fn new(height: Ctx::Height, history_min_height: Ctx::Height) -> Self {
+    pub fn new(
+        tip_height: Ctx::Height,
+        sync_height: Ctx::Height,
+        history_min_height: Ctx::Height,
+    ) -> Self {
         Self {
-            height,
+            tip_height,
+            sync_height,
             history_min_height,
         }
     }
@@ -272,7 +278,8 @@ where
             Msg::BroadcastStatus(status) => {
                 let status = sync::Status {
                     peer_id: ctrl_handle.peer_id(),
-                    height: status.height,
+                    tip_height: status.tip_height,
+                    sync_height: status.sync_height,
                     history_min_height: status.history_min_height,
                 };
 
@@ -380,11 +387,15 @@ where
                     return Ok(());
                 }
 
-                trace!(%from, height = %status.height, "Received status");
+                trace!(%from, height.tip = %status.tip_height, height.sync = %status.sync_height, "Received status");
 
                 output_port.send(NetworkEvent::Status(
                     status.peer_id,
-                    Status::new(status.height, status.history_min_height),
+                    Status::new(
+                        status.tip_height,
+                        status.sync_height,
+                        status.history_min_height,
+                    ),
                 ));
             }
 

--- a/code/crates/engine/src/sync.rs
+++ b/code/crates/engine/src/sync.rs
@@ -220,11 +220,15 @@ where
         use sync::Effect;
 
         match effect {
-            Effect::BroadcastStatus(height) => {
+            Effect::BroadcastStatus {
+                tip_height,
+                sync_height,
+            } => {
                 let history_min_height = self.get_history_min_height().await?;
 
                 self.gossip.cast(NetworkMsg::BroadcastStatus(Status::new(
-                    height,
+                    tip_height,
+                    sync_height,
                     history_min_height,
                 )))?;
             }
@@ -351,7 +355,8 @@ where
             Msg::NetworkEvent(NetworkEvent::Status(peer_id, status)) => {
                 let status = sync::Status {
                     peer_id,
-                    height: status.height,
+                    tip_height: status.tip_height,
+                    sync_height: status.sync_height,
                     history_min_height: status.history_min_height,
                 };
 

--- a/code/crates/starknet/host/src/codec.rs
+++ b/code/crates/starknet/host/src/codec.rs
@@ -173,7 +173,8 @@ pub fn decode_sync_status(
 
     Ok(sync::Status {
         peer_id: decode_peer_id(peer_id)?,
-        height: Height::new(status.block_number, status.fork_id),
+        tip_height: Height::new(status.tip_block_number, status.tip_fork_id),
+        sync_height: Height::new(status.sync_block_number, status.sync_fork_id),
         history_min_height: Height::new(status.earliest_block_number, status.earliest_fork_id),
     })
 }
@@ -183,8 +184,10 @@ pub fn encode_sync_status(
 ) -> Result<proto::sync::Status, ProtoError> {
     Ok(proto::sync::Status {
         peer_id: Some(encode_peer_id(&status.peer_id)?),
-        block_number: status.height.block_number,
-        fork_id: status.height.fork_id,
+        tip_block_number: status.tip_height.block_number,
+        tip_fork_id: status.tip_height.fork_id,
+        sync_block_number: status.sync_height.block_number,
+        sync_fork_id: status.sync_height.fork_id,
         earliest_block_number: status.history_min_height.block_number,
         earliest_fork_id: status.history_min_height.fork_id,
     })

--- a/code/crates/starknet/p2p-proto/proto/sync.proto
+++ b/code/crates/starknet/p2p-proto/proto/sync.proto
@@ -7,10 +7,12 @@ import "p2p/proto/consensus/consensus.proto";
 
 message Status {
   PeerID peer_id = 1;
-  uint64 block_number = 2;
-  uint64 fork_id = 3;
-  uint64 earliest_block_number = 4;
-  uint64 earliest_fork_id = 5;
+  uint64 tip_block_number = 2;
+  uint64 tip_fork_id = 3;
+  uint64 sync_block_number = 5;
+  uint64 sync_fork_id = 6;
+  uint64 earliest_block_number = 7;
+  uint64 earliest_fork_id = 8;
 }
 
 message ValueRequest {

--- a/code/crates/sync/src/state.rs
+++ b/code/crates/sync/src/state.rs
@@ -50,7 +50,7 @@ where
         }
     }
 
-    pub fn update_status(&mut self, status: Status<Ctx>) {
+    pub fn update_peer_status(&mut self, status: Status<Ctx>) {
         self.peers.insert(status.peer_id, status);
     }
 
@@ -70,7 +70,7 @@ where
     pub fn random_peer_with_value(&mut self, height: Ctx::Height) -> Option<PeerId> {
         self.peers
             .iter()
-            .filter_map(move |(&peer, status)| (status.height >= height).then_some(peer))
+            .filter_map(move |(&peer, status)| (status.sync_height > height).then_some(peer))
             .choose_stable(&mut self.rng)
     }
 
@@ -83,7 +83,7 @@ where
     ) -> Option<PeerId> {
         self.peers
             .iter()
-            .filter_map(move |(&peer, status)| (status.height >= height).then_some(peer))
+            .filter_map(move |(&peer, status)| (status.sync_height > height).then_some(peer))
             .filter(|&peer| peer != except)
             .choose_stable(&mut self.rng)
     }

--- a/code/crates/sync/src/types.rs
+++ b/code/crates/sync/src/types.rs
@@ -29,12 +29,11 @@ impl OutboundRequestId {
 
 pub type ResponseChannel = request_response::ResponseChannel<RawResponse>;
 
-#[derive(Display)]
-#[displaydoc("Status {{ peer_id: {peer_id}, height: {height} }}")]
 #[derive_where(Clone, Debug, PartialEq, Eq)]
 pub struct Status<Ctx: Context> {
     pub peer_id: PeerId,
-    pub height: Ctx::Height,
+    pub tip_height: Ctx::Height,
+    pub sync_height: Ctx::Height,
     pub history_min_height: Ctx::Height,
 }
 

--- a/code/crates/test/proto/sync.proto
+++ b/code/crates/test/proto/sync.proto
@@ -10,8 +10,9 @@ message PeerId {
 
 message Status {
     PeerId peer_id = 1;
-    uint64 height = 2;
-    uint64 earliest_height = 3;
+    uint64 tip_height = 2;
+    uint64 sync_height = 3;
+    uint64 earliest_height = 4;
 }
 
 message ValueRequest {

--- a/code/crates/test/src/codec/proto/mod.rs
+++ b/code/crates/test/src/codec/proto/mod.rs
@@ -203,7 +203,8 @@ impl Codec<sync::Status<TestContext>> for ProtobufCodec {
 
         Ok(sync::Status {
             peer_id: PeerId::from_bytes(proto_peer_id.id.as_ref()).unwrap(),
-            height: Height::new(proto.height),
+            tip_height: Height::new(proto.tip_height),
+            sync_height: Height::new(proto.sync_height),
             history_min_height: Height::new(proto.earliest_height),
         })
     }
@@ -213,7 +214,8 @@ impl Codec<sync::Status<TestContext>> for ProtobufCodec {
             peer_id: Some(proto::PeerId {
                 id: Bytes::from(msg.peer_id.to_bytes()),
             }),
-            height: msg.height.as_u64(),
+            tip_height: msg.tip_height.as_u64(),
+            sync_height: msg.sync_height.as_u64(),
             earliest_height: msg.history_min_height.as_u64(),
         };
 


### PR DESCRIPTION
Let's say a node is lagging behind by one height whereas other nodes are stuck at the next height (say because there is not enough online voting power to make progress):

- Lagging node: `tip = 5, sync = 5`
- Stuck nodes: `tip = 5, sync = 6`

In this case, we would expect that lagging node would be able to request a value from one of the stuck nodes. This is not the case right now, because the nodes only broadcast their tip height and not their sync height. Therefore we cannot differentiate between a node who is lagging at height 5 or stuck at height 6, and will not consider any of the stuck nodes for ValueSync.

Because of this, [the test](https://github.com/informalsystems/malachite/pull/952/files#diff-73448f07ace47cb4ffc84bd1fc246ff57ad4f34d516f25cd034429951b6b0b63) that I added in https://github.com/informalsystems/malachite/pull/952 fails because node that just reset its height to 5 will not consider syncing with any of the nodes who are stuck at height 6 and therefore gets stuck at height 5.

---

This PR adds the sync height to the status and changes the logic accordingly.

---

### PR author checklist

#### For all contributors

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
