### PR TITLE
chore(code): Remove decided_sent guard from consensus state

### DIFF
--- a/code/crates/core-consensus/src/handle/decide.rs
+++ b/code/crates/core-consensus/src/handle/decide.rs
@@ -100,14 +100,10 @@ where
         }
     }
 
-    if !state.decided_sent {
-        state.decided_sent = true;
-
-        perform!(
-            co,
-            Effect::Decide(certificate, extensions, Default::default())
-        );
-    }
+    perform!(
+        co,
+        Effect::Decide(certificate, extensions, Default::default())
+    );
 
     Ok(())
 }

--- a/code/crates/core-consensus/src/state.rs
+++ b/code/crates/core-consensus/src/state.rs
@@ -32,13 +32,6 @@ where
 
     /// Last precommit broadcasted by this node
     pub last_signed_precommit: Option<SignedVote<Ctx>>,
-
-    /// The consensus round state machine returns `Decision` output only once.
-    /// When the decision is reached via consensus, `Effect::Decide` is sent to the host
-    /// when the timeout commit elapses. If the node gets the value with the decision
-    /// via sync, while the commit timer is running, it must send the `Effect::Decide` effect immediately.
-    /// Because of this, a guard is needed to ensure the `Effect::Decide` is sent at most once.
-    pub decided_sent: bool,
 }
 
 impl<Ctx> State<Ctx>
@@ -62,7 +55,6 @@ where
             full_proposal_keeper: Default::default(),
             last_signed_prevote: None,
             last_signed_precommit: None,
-            decided_sent: false,
         }
     }
 
@@ -203,7 +195,6 @@ where
         self.full_proposal_keeper.clear();
         self.last_signed_prevote = None;
         self.last_signed_precommit = None;
-        self.decided_sent = false;
 
         self.driver.move_to_height(height, validator_set);
     }


### PR DESCRIPTION
Closes: #985 

---

### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
