### PR TITLE
fix(crates): broken banner on all Malachite crates in crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-<img src="./assets/banner.png" alt="Malachite" width="2400" align="center">
+<img src="https://raw.githubusercontent.com/informalsystems/malachite/refs/heads/main/assets/banner.png" alt="Malachite" width="2400" align="center">
 </h1>
 
 <h4 align="center">


### PR DESCRIPTION
Closes: #1026

This PR proposes a small cosmetic improvement that should be quick to review. It's a very low-priority change — more of a low-hanging fruit — and shouldn't take focus away from core work. The goal is simply to improve how the crate appears on [crates.io](https://crates.io/), giving it a slightly more polished and professional look. 

### How to test

The banner image renders well [on my branch](https://github.com/informalsystems/malachite/tree/andy/1026-crates-banner), and since this is an absolute URL is should work in crates.io too (but not sure if will fix once this is merged or only when a new release for a crate is published)

---

### PR author checklist

#### For all contributors

- [X] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
