### PR TITLE
chore: Remove dependency on `protoc`, use the `protox` crate instead

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,10 +49,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       # - name: Setup Node
       #   uses: actions/setup-node@v3
       #   with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,10 +41,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/mbt.yml
+++ b/.github/workflows/mbt.yml
@@ -40,10 +40,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,10 +43,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -82,10 +78,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -131,10 +123,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -151,10 +139,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -198,10 +182,6 @@ jobs:
         with:
           toolchain: stable
           cache-workspaces: "code"
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install cargo-msrv
         uses: taiki-e/install-action@v2
         with:
@@ -223,10 +203,6 @@ jobs:
         with:
           toolchain: stable
           cache-workspaces: "code"
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -41,10 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable

--- a/CONTRIBUTING_CODE.md
+++ b/CONTRIBUTING_CODE.md
@@ -25,7 +25,6 @@ This document provides guidelines and instructions to help you set up your devel
 To build and test Malachite, you need the following tools:
 
 - **Rust**: Install the latest stable Rust toolchain using [rustup](https://rustup.rs/)
-- **Protocol Buffers Compiler (protoc)**: Required for Protobuf message serialization
 - **Node.js**: Required for running [Quint](https://quint-lang.org)
 - **Quint**: A formal specification language used for our model-based tests
 - **cargo-nextest**: An improved test runner for Rust
@@ -40,25 +39,7 @@ To build and test Malachite, you need the following tools:
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
    ```
 
-2. **Install the Protocol Buffers Compiler**:
-
-   `protoc` is needed for compiling Protobuf definitions used in the test applications to Rust code.
-
-   For Ubuntu/Debian:
-
-   ```bash
-   sudo apt-get install protobuf-compiler
-   ```
-
-   For macOS:
-
-   ```bash
-   brew install protobuf
-   ```
-
-   Please ensure that the version of `protoc` is at least v29.0.
-
-3. **Install Node.js**: (only required for running model-based tests)
+2. **Install Node.js**: (only required for running model-based tests)
 
    Follow the instructions at [nodejs.org](https://nodejs.org/) or use a version manager:
 
@@ -69,19 +50,19 @@ To build and test Malachite, you need the following tools:
    nvm use 21
    ```
 
-4. **Install Quint**: (only required for running model-based tests)
+3. **Install Quint**: (only required for running model-based tests)
 
    ```bash
    npm install -g @informalsystems/quint
    ```
 
-5. **Install cargo-nextest**:
+4. **Install cargo-nextest**:
 
    ```bash
    cargo install cargo-nextest
    ```
 
-6. **Fork and clone the repository**:
+5. **Fork and clone the repository**:
 
    ```bash
    git clone https://github.com/USERNAME/malachite.git

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -424,6 +424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,6 +2435,7 @@ version = "0.3.0-pre"
 dependencies = [
  "prost",
  "prost-build",
+ "protox",
 ]
 
 [[package]]
@@ -2532,6 +2539,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "protox",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -2655,6 +2663,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "protox",
  "seahash",
  "tokio",
  "tracing",
@@ -3290,6 +3299,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
+name = "logos"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6f536c1af4c7cc81edf73da1f8029896e7e1e16a219ef09b184e76a296f3db"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189bbfd0b61330abea797e5e9276408f2edbe4f822d7ad08685d67419aafb34e"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.8.5",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebfe8e1a19049ddbfccbd14ac834b215e11b85b90bab0c2dba7c7b92fb5d5cba"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "loom"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3346,6 +3389,28 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "mime"
@@ -4011,12 +4076,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-reflect"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb644dd3ad12d7cf62a18234d385ea5511ac6abb208704c18098e7e3a5e1b69"
+dependencies = [
+ "logos",
+ "miette",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424c2bd294b69c49b949f3619362bc3c5d28298cd1163b6d1a62df37c16461aa"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57927f9dbeeffcce7192404deee6157a640cbb3fe8ac11eabbe571565949ab75"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5361,6 +5465,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "universal-hash"

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -147,6 +147,7 @@ prometheus-client  = "0.22"
 prost              = "0.13"
 prost-build        = "0.13"
 prost-types        = "0.13"
+protox             = "0.8.0"
 ractor             = { version = "0.14.6", default-features = false, features = ["async-trait", "tokio_runtime"] }
 rand               = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rand_chacha        = "0.3.1"

--- a/code/crates/starknet/p2p-proto/Cargo.toml
+++ b/code/crates/starknet/p2p-proto/Cargo.toml
@@ -12,6 +12,7 @@ prost.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true
+protox.workspace = true
 
 [lints]
 workspace = true

--- a/code/crates/starknet/p2p-proto/build.rs
+++ b/code/crates/starknet/p2p-proto/build.rs
@@ -10,11 +10,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("cargo:rerun-if-changed={proto}");
     }
 
+    let fds = protox::compile(protos, ["./proto"])?;
+
     let mut config = prost_build::Config::new();
     config.bytes(["."]);
     config.enable_type_names();
     config.default_package_filename("p2p");
-    config.compile_protos(protos, &["./proto"])?;
+    config.compile_fds(fds)?;
 
     Ok(())
 }

--- a/code/crates/test/Cargo.toml
+++ b/code/crates/test/Cargo.toml
@@ -49,6 +49,7 @@ tracing.workspace = true
 
 [build-dependencies]
 prost-build = { workspace = true }
+protox = { workspace = true }
 
 [lints]
 workspace = true

--- a/code/crates/test/build.rs
+++ b/code/crates/test/build.rs
@@ -1,17 +1,17 @@
-use std::io::Result;
-
-fn main() -> Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let protos = &["proto/consensus.proto", "proto/sync.proto"];
 
     for proto in protos {
         println!("cargo:rerun-if-changed={proto}");
     }
 
+    let fds = protox::compile(protos, ["proto"])?;
+
     let mut config = prost_build::Config::new();
     config.enable_type_names();
     config.bytes(["."]);
 
-    config.compile_protos(protos, &["proto"])?;
+    config.compile_fds(fds)?;
 
     Ok(())
 }

--- a/code/crates/test/mempool/Cargo.toml
+++ b/code/crates/test/mempool/Cargo.toml
@@ -24,3 +24,4 @@ tracing = { workspace = true }
 
 [build-dependencies]
 prost-build.workspace = true
+protox.workspace = true

--- a/code/crates/test/mempool/build.rs
+++ b/code/crates/test/mempool/build.rs
@@ -1,9 +1,15 @@
-use std::io::Result;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let protos = &["proto/malachite.mempool.proto"];
 
-fn main() -> Result<()> {
+    for proto in protos {
+        println!("cargo:rerun-if-changed={proto}");
+    }
+
+    let fds = protox::compile(protos, ["proto"])?;
+
     let mut config = prost_build::Config::new();
     config.enable_type_names();
-    config.compile_protos(&["proto/malachite.mempool.proto"], &["proto"])?;
+    config.compile_fds(fds)?;
 
     Ok(())
 }

--- a/code/examples/channel/README.md
+++ b/code/examples/channel/README.md
@@ -8,8 +8,7 @@ For more background on this application, [please read the corresponding tutorial
 
 ### Prerequisites
 
-Before running the examples, make sure you have the required development environment setup as specified in this [Setup](../../../CONTRIBUTING_CODE.md#setup) section. 
-This includes the latest Rust toolchain and the Protocol Buffers Compiler (protoc).
+Before running the examples, make sure you have the required development environment setup as specified in this [Setup](../../../CONTRIBUTING_CODE.md#setup) section.
 
 ### Compile the app
 

--- a/docs/testing/local.md
+++ b/docs/testing/local.md
@@ -29,22 +29,14 @@ $ docker run -it -v .:/app --cap-add=NET_ADMIN rust:1-slim /bin/bash
 # apt install -y wget unzip git iproute2 procps iputils-ping curl vim make
 ```
 
-4. Install the Protobuf compiler
-
-```
-# wget https://github.com/protocolbuffers/protobuf/releases/download/v28.0/protoc-28.0-linux-aarch_64.zip
-# unzip -d /usr/local protoc-28.0-linux-aarch_64.zip
-# rm -f protoc-28.0-linux-aarch_64.zip
-```
-
-5. Build Malachite
+4. Build Malachite
 
 ```
 # cd app/code
 # cargo build --release
 ```
 
-6. Introduce network latency (optional)
+5. Introduce network latency (optional)
 
 To introduce 50ms latency in both ingress and egress on the loopback interface,
 so a total 100ms round-trip time between localhost to itself:
@@ -67,7 +59,7 @@ To restore it back to normal:
 
 **Note:** To modify these settings, you first need to disable them using the command above before re-introducing them.
 
-7. Test the latency to localhost
+6. Test the latency to localhost
 
 ```
 # ping 127.0.0.1
@@ -77,25 +69,25 @@ PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
 64 bytes from 127.0.0.1: icmp_seq=3 ttl=64 time=109 ms
 ```
 
-8. Generate the testnet configuration in the directory `x`
+7. Generate the testnet configuration in the directory `x`
 
 ```
 # cargo run --release -- testnet --nodes 20 --home x -d
 ```
 
-9. In `scripts/spawn.bash`, modify the environment variables controlling the config according your needs
+8. In `scripts/spawn.bash`, modify the environment variables controlling the config according your needs
 
 ```
 # vim scripts/spawn.bash
 ```
 
-10. Run the devnet
+9. Run the devnet
 
 ```
 # ./scripts/spawn.bash --nodes 20 --home x
 ```
 
-11. Open another session to the container from the host machine
+10. Open another session to the container from the host machine
 
 For this, first find the name of the container that is running, then open a new bash shell within it:
 
@@ -104,13 +96,13 @@ $ docker ps
 $ docker exec -it CONTAINER_NAME /bin/bash
 ```
 
-12. In this new session, check the logs
+11. In this new session, check the logs
 
 ```
 # tail -f app/code/x/0/logs/node.log
 ```
 
-13. Check the metrics
+12. Check the metrics
 
 For the block time:
 


### PR DESCRIPTION
This PR removes the dependency on `protoc`, instead using [`protox`](https://lib.rs/protox) to compile the Protobuf definitions to file descriptors and have those compiled to Rust code by `prost`. This simplifies the setup for contributors, app builders and the CI.

---

### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
