### PR TITLE
feat(code): Compute and show in logs the role of the node during a round

### DIFF
--- a/code/crates/app-channel/src/connector.rs
+++ b/code/crates/app-channel/src/connector.rs
@@ -79,6 +79,7 @@ where
                 height,
                 round,
                 proposer,
+                role,
             } => {
                 let (reply_value, rx_value) = oneshot::channel();
 
@@ -87,6 +88,7 @@ where
                         height,
                         round,
                         proposer,
+                        role,
                         reply_value,
                     })
                     .await?;

--- a/code/crates/app-channel/src/msgs.rs
+++ b/code/crates/app-channel/src/msgs.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use derive_where::derive_where;
+use malachitebft_app::consensus::Role;
 use malachitebft_app::types::core::ValueOrigin;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
@@ -49,6 +50,8 @@ pub enum AppMsg<Ctx: Context> {
         round: Round,
         /// Proposer for that round
         proposer: Ctx::Address,
+        /// Role that this node is playing in this round
+        role: Role,
         /// Channel for sending back previously received undecided values to consensus
         reply_value: Reply<Vec<ProposedValue<Ctx>>>,
     },

--- a/code/crates/core-consensus/src/effect.rs
+++ b/code/crates/core-consensus/src/effect.rs
@@ -3,7 +3,7 @@ use derive_where::derive_where;
 use malachitebft_core_types::*;
 
 use crate::types::{LivenessMsg, SignedConsensusMsg};
-use crate::{ConsensusMsg, VoteExtensionError, WalEntry};
+use crate::{ConsensusMsg, Role, VoteExtensionError, WalEntry};
 
 /// Provides a way to construct the appropriate [`Resume`] value to
 /// resume execution after handling an [`Effect`].
@@ -76,7 +76,7 @@ where
     /// Consensus is starting a new round with the given proposer
     ///
     /// Resume with: [`resume::Continue`]
-    StartRound(Ctx::Height, Round, Ctx::Address, resume::Continue),
+    StartRound(Ctx::Height, Round, Ctx::Address, Role, resume::Continue),
 
     /// Publish a message to peers
     ///

--- a/code/crates/core-consensus/src/types.rs
+++ b/code/crates/core-consensus/src/types.rs
@@ -11,6 +11,17 @@ pub use malachitebft_core_types::ValuePayload;
 pub use malachitebft_peer::PeerId;
 pub use multiaddr::Multiaddr;
 
+/// The role that the node is playing in the consensus protocol during a round.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Role {
+    /// The node is the proposer for the current round.
+    Proposer,
+    /// The node is a validator for the current round.
+    Validator,
+    /// The node is not participating in the consensus protocol for the current round.
+    None,
+}
+
 /// A signed consensus message, ie. a signed vote or a signed proposal.
 #[derive_where(Clone, Debug, PartialEq, Eq)]
 pub enum SignedConsensusMsg<Ctx: Context> {

--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -927,16 +927,18 @@ where
                 Ok(r.resume_with(()))
             }
 
-            Effect::StartRound(height, round, proposer, r) => {
+            Effect::StartRound(height, round, proposer, role, r) => {
                 self.wal_flush(state.phase).await?;
 
                 self.host.cast(HostMsg::StartedRound {
                     height,
                     round,
-                    proposer,
+                    proposer: proposer.clone(),
+                    role,
                 })?;
 
-                self.tx_event.send(|| Event::StartedRound(height, round));
+                self.tx_event
+                    .send(|| Event::StartedRound(height, round, proposer, role));
 
                 Ok(r.resume_with(()))
             }

--- a/code/crates/engine/src/host.rs
+++ b/code/crates/engine/src/host.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use derive_where::derive_where;
 use ractor::{ActorRef, RpcReplyPort};
 
-use malachitebft_core_consensus::VoteExtensionError;
+use malachitebft_core_consensus::{Role, VoteExtensionError};
 use malachitebft_core_types::{CommitCertificate, Context, Round, ValueId, VoteExtensions};
 use malachitebft_sync::{PeerId, RawDecidedValue};
 
@@ -27,6 +27,7 @@ pub enum HostMsg<Ctx: Context> {
         height: Ctx::Height,
         round: Round,
         proposer: Ctx::Address,
+        role: Role,
     },
 
     /// Request to build a local value to propose

--- a/code/crates/engine/src/util/events.rs
+++ b/code/crates/engine/src/util/events.rs
@@ -6,7 +6,7 @@ use ractor::ActorProcessingErr;
 use tokio::sync::broadcast;
 
 use malachitebft_core_consensus::{
-    LocallyProposedValue, ProposedValue, SignedConsensusMsg, WalEntry,
+    LocallyProposedValue, ProposedValue, Role, SignedConsensusMsg, WalEntry,
 };
 use malachitebft_core_types::{
     CommitCertificate, Context, PolkaCertificate, Round, RoundCertificate, SignedVote, ValueOrigin,
@@ -45,7 +45,7 @@ impl<Ctx: Context> Default for TxEvent<Ctx> {
 #[derive_where(Clone, Debug)]
 pub enum Event<Ctx: Context> {
     StartedHeight(Ctx::Height, bool),
-    StartedRound(Ctx::Height, Round),
+    StartedRound(Ctx::Height, Round, Ctx::Address, Role),
     Published(SignedConsensusMsg<Ctx>),
     ProposedValue(LocallyProposedValue<Ctx>),
     ReceivedProposedValue(ProposedValue<Ctx>, ValueOrigin),
@@ -66,8 +66,8 @@ impl<Ctx: Context> fmt::Display for Event<Ctx> {
             Event::StartedHeight(height, restart) => {
                 write!(f, "StartedHeight(height: {height}, restart: {restart})")
             }
-            Event::StartedRound(height, round) => {
-                write!(f, "StartedRound(height: {height}, round: {round})")
+            Event::StartedRound(height, round, proposer, role) => {
+                write!(f, "StartedRound(height: {height}, round: {round}, proposer: {proposer}, role: {role:?})")
             }
             Event::Published(msg) => write!(f, "Published(msg: {msg:?})"),
             Event::ProposedValue(value) => write!(f, "ProposedValue(value: {value:?})"),

--- a/code/crates/starknet/host/src/actor.rs
+++ b/code/crates/starknet/host/src/actor.rs
@@ -10,7 +10,7 @@ use rand::SeedableRng;
 use tokio::time::Instant;
 use tracing::{debug, error, info, trace, warn};
 
-use malachitebft_core_consensus::{PeerId, VoteExtensionError};
+use malachitebft_core_consensus::{PeerId, Role, VoteExtensionError};
 use malachitebft_core_types::{CommitCertificate, Round, Validity, ValueId, ValueOrigin};
 use malachitebft_engine::consensus::{ConsensusMsg, ConsensusRef};
 use malachitebft_engine::host::{LocallyProposedValue, ProposedValue};
@@ -131,7 +131,8 @@ impl Host {
                 height,
                 round,
                 proposer,
-            } => on_started_round(state, height, round, proposer).await,
+                role,
+            } => on_started_round(state, height, round, proposer, role).await,
 
             HostMsg::GetHistoryMinHeight { reply_to } => {
                 on_get_history_min_height(state, reply_to).await
@@ -259,10 +260,14 @@ async fn on_started_round(
     height: Height,
     round: Round,
     proposer: Address,
+    role: Role,
 ) -> Result<(), ActorProcessingErr> {
     state.height = height;
     state.round = round;
     state.proposer = Some(proposer);
+    state.role = role;
+
+    info!(%height, %round, %proposer, ?role, "Started new round");
 
     // If we have already built or seen one or more values for this height and round,
     // feed them back to consensus. This may happen when we are restarting after a crash.

--- a/code/crates/starknet/host/src/host/state.rs
+++ b/code/crates/starknet/host/src/host/state.rs
@@ -1,3 +1,4 @@
+use malachitebft_core_consensus::Role;
 use sha3::Digest;
 use std::path::Path;
 use std::sync::Arc;
@@ -22,6 +23,7 @@ pub struct HostState {
     pub height: Height,
     pub round: Round,
     pub proposer: Option<Address>,
+    pub role: Role,
     pub host: StarknetHost,
     pub consensus: Option<ConsensusRef<MockContext>>,
     pub block_store: BlockStore,
@@ -44,6 +46,7 @@ impl HostState {
             height: Height::new(0, 0),
             round: Round::Nil,
             proposer: None,
+            role: Role::None,
             host,
             consensus: None,
             block_store: BlockStore::new(db_path).await.unwrap(),

--- a/code/crates/test/app/src/app.rs
+++ b/code/crates/test/app/src/app.rs
@@ -56,9 +56,10 @@ pub async fn run(
                 height,
                 round,
                 proposer,
+                role,
                 reply_value,
             } => {
-                info!(%height, %round, %proposer, "Started round");
+                info!(%height, %round, %proposer, ?role, "Started round");
 
                 // We can use that opportunity to update our internal state
                 state.current_height = height;

--- a/code/crates/test/app/src/state.rs
+++ b/code/crates/test/app/src/state.rs
@@ -10,7 +10,7 @@ use rand::{Rng, SeedableRng};
 use sha3::Digest;
 use tracing::{debug, error};
 
-use malachitebft_app_channel::app::consensus::ProposedValue;
+use malachitebft_app_channel::app::consensus::{ProposedValue, Role};
 use malachitebft_app_channel::app::streaming::{StreamContent, StreamId, StreamMessage};
 use malachitebft_app_channel::app::types::codec::Codec;
 use malachitebft_app_channel::app::types::core::{CommitCertificate, Round, Validity};
@@ -38,6 +38,7 @@ pub struct State {
     pub current_height: Height,
     pub current_round: Round,
     pub current_proposer: Option<Address>,
+    pub current_role: Role,
     pub peers: HashSet<PeerId>,
     pub store: Store,
 
@@ -67,6 +68,7 @@ impl State {
             current_height: height,
             current_round: Round::new(0),
             current_proposer: None,
+            current_role: Role::None,
             streams_map: PartStreamsMap::new(),
             rng: StdRng::from_entropy(),
             peers: HashSet::new(),

--- a/code/crates/test/framework/src/lib.rs
+++ b/code/crates/test/framework/src/lib.rs
@@ -292,11 +292,11 @@ where
                         return TestResult::Failure(failure);
                     }
 
-                    let Event::StartedRound(_, round) = event else {
+                    let Event::StartedRound(_, round, _, role) = event else {
                         continue 'inner;
                     };
 
-                    info!("Node started round {round}");
+                    info!(%round, ?role, "Node started round");
 
                     if round.as_u32() == Some(target_round) {
                         break 'inner;

--- a/code/examples/channel/src/app.rs
+++ b/code/examples/channel/src/app.rs
@@ -46,9 +46,10 @@ pub async fn run(state: &mut State, channels: &mut Channels<TestContext>) -> eyr
                 height,
                 round,
                 proposer,
+                role,
                 reply_value,
             } => {
-                info!(%height, %round, %proposer, "Started round");
+                info!(%height, %round, %proposer, ?role, "Started round");
 
                 reload_log_level(height, round);
 


### PR DESCRIPTION
When starting a round, show the role of the node for that round.

Roles are:

- Proposer, if the node is the proposer
- Validator, if the node is in the validator set
- None, if the node is not in the validator set

---

### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
