### PR TITLE
feat(sync/batching): simplify app interface

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -38,6 +38,9 @@
 - Removed the VoteSet synchronization protocol, as it is neither required nor sufficient for liveness.
   See ([#998](https://github.com/informalsystems/malachite/issues/998)) for more details.
 
+#### Enum Changes
+- Replaces existing enum `GetDecidedValue` by `GetDecidedValues` in `Effect`
+
 ### `informalsystems-malachitebft-app-channel`
 - The `start_engine` function now takes two `Codec`s: one for the WAL and one for the network.
 

--- a/code/crates/app-channel/src/connector.rs
+++ b/code/crates/app-channel/src/connector.rs
@@ -252,16 +252,6 @@ where
                 consensus.cast(rx.await?.into())?;
             }
 
-            HostMsg::GetDecidedValue { height, reply_to } => {
-                let (reply, rx) = oneshot::channel();
-
-                self.sender
-                    .send(AppMsg::GetDecidedValue { height, reply })
-                    .await?;
-
-                reply_to.send(rx.await?)?;
-            }
-
             HostMsg::GetDecidedValues { range, reply_to } => {
                 let (reply, rx) = oneshot::channel();
 

--- a/code/crates/app-channel/src/msgs.rs
+++ b/code/crates/app-channel/src/msgs.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::ops::RangeInclusive;
 use std::time::Duration;
 
@@ -181,7 +180,7 @@ pub enum AppMsg<Ctx: Context> {
         /// Range of heights for which to retrieve decided values
         range: RangeInclusive<Ctx::Height>,
         /// Channel for sending back the decided values
-        reply: Reply<BTreeMap<Ctx::Height, Option<RawDecidedValue<Ctx>>>>,
+        reply: Reply<Vec<RawDecidedValue<Ctx>>>,
     },
 
     /// Notifies the application that a value has been synced from the network.

--- a/code/crates/app-channel/src/msgs.rs
+++ b/code/crates/app-channel/src/msgs.rs
@@ -163,21 +163,14 @@ pub enum AppMsg<Ctx: Context> {
         reply: Reply<ConsensusMsg<Ctx>>,
     },
 
-    /// Requests a previously decided value from the application's storage.
+    /// Requests a range of previously decided values from the application's storage.
     ///
-    /// The application MUST respond with that value if available, or `None` otherwise.
-    GetDecidedValue {
-        /// Height of the decided value to retrieve
-        height: Ctx::Height,
-        /// Channel for sending back the decided value
-        reply: Reply<Option<RawDecidedValue<Ctx>>>,
-    },
-
-    /// Requests a batch of previously decided values from the application's storage.
-    ///
-    /// The application MUST respond with a map of heights to decided values
+    /// The application MUST respond with:
+    /// - all decided values in the range, if available,
+    /// - a prefix of the list of requested values, in case one of them is not available (that is, discarding the rest of the range)
+    /// - or an empty list otherwise.
     GetDecidedValues {
-        /// Range of heights for which to retrieve decided values
+        /// Range of heights to retrieve
         range: RangeInclusive<Ctx::Height>,
         /// Channel for sending back the decided values
         reply: Reply<Vec<RawDecidedValue<Ctx>>>,

--- a/code/crates/discovery/src/handlers/close.rs
+++ b/code/crates/discovery/src/handlers/close.rs
@@ -20,9 +20,7 @@ where
             || self
                 .active_connections
                 .get(&peer_id)
-                .map_or(true, |connection_ids| {
-                    !connection_ids.contains(&connection_id)
-                })
+                .is_none_or(|connection_ids| !connection_ids.contains(&connection_id))
     }
 
     pub fn close_connection(

--- a/code/crates/discovery/src/handlers/peers_management.rs
+++ b/code/crates/discovery/src/handlers/peers_management.rs
@@ -64,7 +64,7 @@ where
             .filter(|(peer_id, _)| !self.outbound_peers.contains_key(peer_id))
             // Remove inbound peers
             .filter(|(peer_id, _)| !self.inbound_peers.contains(peer_id))
-            .map(|(peer_id, connection_ids)| ((*peer_id).clone(), connection_ids.clone()))
+            .map(|(peer_id, connection_ids)| (*peer_id, connection_ids.clone()))
             .collect();
 
         debug!(

--- a/code/crates/discovery/src/metrics.rs
+++ b/code/crates/discovery/src/metrics.rs
@@ -208,6 +208,7 @@ impl Metrics {
         self.total_discovered.inc();
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn set_connections_status(
         &self,
         num_active_peers: usize,

--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -457,12 +457,15 @@ where
                     NetworkEvent::SyncResponse(
                         request_id,
                         peer,
-                        Some(sync::Response::ValueResponse(ValueResponse { range, values })),
+                        Some(sync::Response::ValueResponse(ValueResponse {
+                            start_height,
+                            values,
+                        })),
                     ) => {
-                        debug!(from = %range.start(), to = %range.end(), %request_id, "Received sync response");
+                        debug!(%start_height, %request_id, "Received sync response with {} values", values.len());
 
                         // Process values sequentially starting from the lowest height
-                        let mut height = *range.start();
+                        let mut height = start_height;
                         for value in values.iter() {
                             self.process_sync_response(
                                 &myself,

--- a/code/crates/engine/src/host.rs
+++ b/code/crates/engine/src/host.rs
@@ -102,13 +102,7 @@ pub enum HostMsg<Ctx: Context> {
         consensus: ConsensusRef<Ctx>,
     },
 
-    // Retrieve decided value from the block store
-    GetDecidedValue {
-        height: Ctx::Height,
-        reply_to: RpcReplyPort<Option<RawDecidedValue<Ctx>>>,
-    },
-
-    // Retrieve decided values in a batch from the block store
+    // Retrieve decided values from the block store
     GetDecidedValues {
         range: RangeInclusive<Ctx::Height>,
         reply_to: RpcReplyPort<Vec<RawDecidedValue<Ctx>>>,

--- a/code/crates/engine/src/host.rs
+++ b/code/crates/engine/src/host.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use std::{collections::BTreeMap, ops::RangeInclusive, time::Duration};
+use std::{ops::RangeInclusive, time::Duration};
 
 use derive_where::derive_where;
 use ractor::{ActorRef, RpcReplyPort};
@@ -111,7 +111,7 @@ pub enum HostMsg<Ctx: Context> {
     // Retrieve decided values in a batch from the block store
     GetDecidedValues {
         range: RangeInclusive<Ctx::Height>,
-        reply_to: RpcReplyPort<BTreeMap<Ctx::Height, Option<RawDecidedValue<Ctx>>>>,
+        reply_to: RpcReplyPort<Vec<RawDecidedValue<Ctx>>>,
     },
 
     // Process a value synced from another node via the ValueSync protocol.

--- a/code/crates/engine/src/sync.rs
+++ b/code/crates/engine/src/sync.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use std::time::Duration;
 
@@ -97,7 +97,7 @@ pub enum Msg<Ctx: Context> {
     GotDecidedBlocks(
         InboundRequestId,
         RangeInclusive<Ctx::Height>,
-        BTreeMap<Ctx::Height, Option<RawDecidedValue<Ctx>>>,
+        Vec<RawDecidedValue<Ctx>>,
     ),
 
     /// A timeout has elapsed

--- a/code/crates/starknet/p2p-proto/proto/sync.proto
+++ b/code/crates/starknet/p2p-proto/proto/sync.proto
@@ -17,12 +17,13 @@ message Status {
 message ValueRequest {
   uint64 block_number = 1;
   uint64 fork_id = 2;
+  optional uint64 end_block_number = 3;
 }
 
 message ValueResponse {
   uint64 block_number = 1;
   uint64 fork_id = 2;
-  SyncedValue value = 3;
+  repeated SyncedValue value = 3;
 }
 
 message SyncedValue {

--- a/code/crates/starknet/p2p-proto/proto/sync.proto
+++ b/code/crates/starknet/p2p-proto/proto/sync.proto
@@ -23,7 +23,7 @@ message ValueRequest {
 message ValueResponse {
   uint64 block_number = 1;
   uint64 fork_id = 2;
-  repeated SyncedValue value = 3;
+  repeated SyncedValue values = 3;
 }
 
 message SyncedValue {

--- a/code/crates/sync/src/effect.rs
+++ b/code/crates/sync/src/effect.rs
@@ -6,9 +6,7 @@ use thiserror::Error;
 use malachitebft_core_types::Context;
 use malachitebft_peer::PeerId;
 
-use crate::{
-    BatchRequest, BatchResponse, InboundRequestId, OutboundRequestId, ValueRequest, ValueResponse,
-};
+use crate::{InboundRequestId, OutboundRequestId, ValueRequest, ValueResponse};
 
 /// Provides a way to construct the appropriate [`Resume`] value to
 /// resume execution after handling an [`Effect`].
@@ -73,16 +71,7 @@ pub enum Effect<Ctx: Context> {
     /// Send a response to a ValueSync request
     SendValueResponse(InboundRequestId, ValueResponse<Ctx>, resume::Continue),
 
-    /// Send a BatchSync request to a peer
-    SendBatchRequest(PeerId, BatchRequest<Ctx>, resume::ValueRequestId),
-
-    /// Send a response to a BatchSync request
-    SendBatchResponse(InboundRequestId, BatchResponse<Ctx>, resume::Continue),
-
-    /// Retrieve a value from the application
-    GetDecidedValue(InboundRequestId, Ctx::Height, resume::Continue),
-
-    /// Retrieve a batch of values from the application
+    /// Retrieve a range of values (possibly one) from the application
     GetDecidedValues(
         InboundRequestId,
         RangeInclusive<Ctx::Height>,

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -568,10 +568,9 @@ where
     let mut end_height = height;
     let request_id = if batch_size > 1 {
         end_height = end_height.increment_by(batch_size);
-        let max_response_size = 10 * 1024 * 1024; // 10 MiB
         perform!(
             co,
-            Effect::SendBatchRequest(peer, BatchRequest::new(RangeInclusive::new(height, end_height), max_response_size), Default::default()),
+            Effect::SendBatchRequest(peer, BatchRequest::new(RangeInclusive::new(height, end_height)), Default::default()),
             Resume::ValueRequestId(id) => id,
         )
     } else {

--- a/code/crates/sync/src/types.rs
+++ b/code/crates/sync/src/types.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc};
+use std::{ops::RangeInclusive, sync::Arc};
 
 use bytes::Bytes;
 use derive_where::derive_where;
@@ -121,14 +121,11 @@ impl<Ctx: Context> BatchRequest<Ctx> {
 #[derive_where(Clone, Debug, PartialEq, Eq)]
 pub struct BatchResponse<Ctx: Context> {
     pub range: RangeInclusive<Ctx::Height>,
-    pub values: BTreeMap<Ctx::Height, Option<RawDecidedValue<Ctx>>>,
+    pub values: Vec<RawDecidedValue<Ctx>>,
 }
 
 impl<Ctx: Context> BatchResponse<Ctx> {
-    pub fn new(
-        range: RangeInclusive<Ctx::Height>,
-        values: BTreeMap<Ctx::Height, Option<RawDecidedValue<Ctx>>>,
-    ) -> Self {
+    pub fn new(range: RangeInclusive<Ctx::Height>, values: Vec<RawDecidedValue<Ctx>>) -> Self {
         Self { range, values }
     }
 }

--- a/code/crates/sync/src/types.rs
+++ b/code/crates/sync/src/types.rs
@@ -91,13 +91,27 @@ impl<Ctx: Context> ValueRequest<Ctx> {
 
 #[derive_where(Clone, Debug, PartialEq, Eq)]
 pub struct ValueResponse<Ctx: Context> {
-    pub range: RangeInclusive<Ctx::Height>,
+    /// The height of the first value in the response.
+    pub start_height: Ctx::Height,
+
+    /// Values are sequentially ordered by height.
     pub values: Vec<RawDecidedValue<Ctx>>,
 }
 
 impl<Ctx: Context> ValueResponse<Ctx> {
-    pub fn new(range: RangeInclusive<Ctx::Height>, values: Vec<RawDecidedValue<Ctx>>) -> Self {
-        Self { range, values }
+    pub fn new(start_height: Ctx::Height, values: Vec<RawDecidedValue<Ctx>>) -> Self {
+        Self {
+            start_height,
+            values,
+        }
+    }
+
+    pub fn end_height(&self) -> Option<Ctx::Height> {
+        if self.values.is_empty() {
+            None
+        } else {
+            Some(self.start_height.increment_by(self.values.len() as u64 - 1))
+        }
     }
 }
 

--- a/code/crates/sync/src/types.rs
+++ b/code/crates/sync/src/types.rs
@@ -70,57 +70,32 @@ impl<Ctx: Context> PeerDetails<Ctx> {
 
 #[derive_where(Clone, Debug, PartialEq, Eq)]
 pub enum Request<Ctx: Context> {
-    ValueRequest(ValueRequest<Ctx>), // Sync v1
-    BatchRequest(BatchRequest<Ctx>), // Sync v2
+    ValueRequest(ValueRequest<Ctx>),
 }
 
 #[derive_where(Clone, Debug, PartialEq, Eq)]
 pub enum Response<Ctx: Context> {
-    ValueResponse(ValueResponse<Ctx>), // Sync v1
-    BatchResponse(BatchResponse<Ctx>), // Sync v2
+    ValueResponse(ValueResponse<Ctx>),
 }
 
 #[derive_where(Clone, Debug, PartialEq, Eq)]
 pub struct ValueRequest<Ctx: Context> {
-    pub height: Ctx::Height,
-}
-
-impl<Ctx: Context> ValueRequest<Ctx> {
-    pub fn new(height: Ctx::Height) -> Self {
-        Self { height }
-    }
-}
-
-#[derive_where(Clone, Debug, PartialEq, Eq)]
-pub struct ValueResponse<Ctx: Context> {
-    pub height: Ctx::Height,
-    pub value: Option<RawDecidedValue<Ctx>>,
-}
-
-impl<Ctx: Context> ValueResponse<Ctx> {
-    pub fn new(height: Ctx::Height, value: Option<RawDecidedValue<Ctx>>) -> Self {
-        Self { height, value }
-    }
-}
-
-#[derive_where(Clone, Debug, PartialEq, Eq)]
-pub struct BatchRequest<Ctx: Context> {
     pub range: RangeInclusive<Ctx::Height>,
 }
 
-impl<Ctx: Context> BatchRequest<Ctx> {
+impl<Ctx: Context> ValueRequest<Ctx> {
     pub fn new(range: RangeInclusive<Ctx::Height>) -> Self {
         Self { range }
     }
 }
 
 #[derive_where(Clone, Debug, PartialEq, Eq)]
-pub struct BatchResponse<Ctx: Context> {
+pub struct ValueResponse<Ctx: Context> {
     pub range: RangeInclusive<Ctx::Height>,
     pub values: Vec<RawDecidedValue<Ctx>>,
 }
 
-impl<Ctx: Context> BatchResponse<Ctx> {
+impl<Ctx: Context> ValueResponse<Ctx> {
     pub fn new(range: RangeInclusive<Ctx::Height>, values: Vec<RawDecidedValue<Ctx>>) -> Self {
         Self { range, values }
     }

--- a/code/crates/sync/src/types.rs
+++ b/code/crates/sync/src/types.rs
@@ -106,15 +106,11 @@ impl<Ctx: Context> ValueResponse<Ctx> {
 #[derive_where(Clone, Debug, PartialEq, Eq)]
 pub struct BatchRequest<Ctx: Context> {
     pub range: RangeInclusive<Ctx::Height>,
-    pub max_response_size: usize,
 }
 
 impl<Ctx: Context> BatchRequest<Ctx> {
-    pub fn new(range: RangeInclusive<Ctx::Height>, max_response_size: usize) -> Self {
-        Self {
-            range,
-            max_response_size,
-        }
+    pub fn new(range: RangeInclusive<Ctx::Height>) -> Self {
+        Self { range }
     }
 }
 

--- a/code/crates/test/app/src/app.rs
+++ b/code/crates/test/app/src/app.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::time::Duration;
 
 use eyre::eyre;
@@ -312,19 +311,15 @@ pub async fn run(
                 let decided_values = state.get_decided_values(range.clone()).await;
                 info!(from = %range.start(), to = %range.end(), "Found decided values: {decided_values:?}");
 
-                let raw_decided_values: BTreeMap<Height, Option<RawDecidedValue<TestContext>>> =
-                    decided_values
-                        .into_iter()
-                        .map(|(height, decided_value)| {
-                            (
-                                height,
-                                Some(RawDecidedValue {
-                                    certificate: decided_value.certificate,
-                                    value_bytes: JsonCodec.encode(&decided_value.value).unwrap(), // FIXME: unwrap
-                                }),
-                            )
-                        })
-                        .collect();
+                let raw_decided_values: Vec<RawDecidedValue<TestContext>> = decided_values
+                    .into_iter()
+                    .map(|decided_value| {
+                        RawDecidedValue {
+                            value_bytes: JsonCodec.encode(&decided_value.value).unwrap(), // FIXME: unwrap
+                            certificate: decided_value.certificate,
+                        }
+                    })
+                    .collect();
 
                 if reply.send(raw_decided_values).is_err() {
                     error!("Failed to send GetDecidedValues reply");

--- a/code/crates/test/app/src/app.rs
+++ b/code/crates/test/app/src/app.rs
@@ -285,26 +285,10 @@ pub async fn run(
             }
 
             // If, on the other hand, we are not lagging behind but are instead asked by one of
-            // our peer to help them catch up because they are the one lagging behind,
-            // then the engine might ask the application to provide with the value
-            // that was decided at some lower height. In that case, we fetch it from our store
-            // and send it to consensus.
-            AppMsg::GetDecidedValue { height, reply } => {
-                info!(%height, "Received sync request for decided value");
-
-                let decided_value = state.get_decided_value(height).await;
-                info!(%height, "Found decided value: {decided_value:?}");
-
-                let raw_decided_value = decided_value.map(|decided_value| RawDecidedValue {
-                    certificate: decided_value.certificate,
-                    value_bytes: JsonCodec.encode(&decided_value.value).unwrap(), // FIXME: unwrap
-                });
-
-                if reply.send(raw_decided_value).is_err() {
-                    error!("Failed to send GetDecidedValue reply");
-                }
-            }
-
+            // our peers to help them catch up because they are the one lagging behind,
+            // then the engine might ask the application to provide with the values
+            // that were decided at some lower heights. In that case, we fetch them from our store
+            // and send them to consensus.
             AppMsg::GetDecidedValues { range, reply } => {
                 info!(from = %range.start(), to = %range.end(), "Received sync request for decided values");
 

--- a/code/crates/test/app/src/state.rs
+++ b/code/crates/test/app/src/state.rs
@@ -1,7 +1,7 @@
 //! Internal state of the application. This is a simplified abstract to keep it simple.
 //! A regular application would have mempool implemented, a proper database and input methods like RPC.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 use std::ops::RangeInclusive;
 
 use bytes::Bytes;
@@ -158,10 +158,7 @@ impl State {
     }
 
     /// Retrieves decided values in the range from `from` to `to` heights.
-    pub async fn get_decided_values(
-        &self,
-        range: RangeInclusive<Height>,
-    ) -> BTreeMap<Height, DecidedValue> {
+    pub async fn get_decided_values(&self, range: RangeInclusive<Height>) -> Vec<DecidedValue> {
         self.store
             .get_decided_values(range)
             .await

--- a/code/crates/test/app/src/store.rs
+++ b/code/crates/test/app/src/store.rs
@@ -303,6 +303,7 @@ impl Store {
         let db = Arc::clone(&self.db);
         tokio::task::spawn_blocking(move || {
             // TODO: optimize this to avoid multiple database reads
+
             let mut values = Vec::new();
             for h in range.start().as_u64()..=range.end().as_u64() {
                 if let Some(value) = db.get_decided_value(Height::new(h))? {

--- a/code/crates/test/proto/sync.proto
+++ b/code/crates/test/proto/sync.proto
@@ -17,6 +17,8 @@ message Status {
 
 message ValueRequest {
     uint64 height = 1;
+    optional uint64 end_height = 2;
+    optional uint64 max_response_size = 3;
 }
 
 message ValueResponse {
@@ -24,26 +26,14 @@ message ValueResponse {
     SyncedValue value = 2;
 }
 
-message BatchRequest {
-    uint64 from_height = 1;
-    uint64 to_height = 2;
-    uint64 max_response_size = 3;
-}
-
 message BatchResponse {
-    uint64 from_height = 1;
-    uint64 to_height = 2;
-    repeated BatchSyncValue values = 3;
+    uint64 height = 1;
+    repeated SyncedValue values = 2;
 }
 
 message SyncedValue {
     bytes value_bytes = 1;
     CommitCertificate certificate = 2;
-}
-
-message BatchSyncValue {
-    uint64 height = 1;
-    SyncedValue value = 2;
 }
 
 message CommitSignature {
@@ -71,7 +61,6 @@ message ProposedValue {
 message SyncRequest {
   oneof request {
     ValueRequest value_request = 1;
-    BatchRequest batch_request = 2;
   }
 }
 
@@ -81,4 +70,3 @@ message SyncResponse {
     BatchResponse batch_response = 2;
   }
 }
-

--- a/code/crates/test/proto/sync.proto
+++ b/code/crates/test/proto/sync.proto
@@ -21,8 +21,8 @@ message ValueRequest {
 }
 
 message ValueResponse {
-    uint64 height = 1;
-    repeated SyncedValue value = 2;
+    uint64 start_height = 1;
+    repeated SyncedValue values = 2;
 }
 
 message SyncedValue {

--- a/code/crates/test/proto/sync.proto
+++ b/code/crates/test/proto/sync.proto
@@ -18,7 +18,6 @@ message Status {
 message ValueRequest {
     uint64 height = 1;
     optional uint64 end_height = 2;
-    optional uint64 max_response_size = 3;
 }
 
 message ValueResponse {

--- a/code/crates/test/proto/sync.proto
+++ b/code/crates/test/proto/sync.proto
@@ -22,12 +22,7 @@ message ValueRequest {
 
 message ValueResponse {
     uint64 height = 1;
-    SyncedValue value = 2;
-}
-
-message BatchResponse {
-    uint64 height = 1;
-    repeated SyncedValue values = 2;
+    repeated SyncedValue value = 2;
 }
 
 message SyncedValue {
@@ -66,6 +61,5 @@ message SyncRequest {
 message SyncResponse {
   oneof response {
     ValueResponse value_response = 1;
-    BatchResponse batch_response = 2;
   }
 }

--- a/code/crates/test/src/codec/json/raw.rs
+++ b/code/crates/test/src/codec/json/raw.rs
@@ -249,15 +249,14 @@ pub struct RawSyncedValue {
 
 #[derive(Serialize, Deserialize)]
 pub struct ValueRawResponse {
-    pub height: Height,
+    pub start_height: Height,
     pub value: Vec<RawSyncedValue>,
 }
 
 impl From<ValueResponse<TestContext>> for ValueRawResponse {
     fn from(response: ValueResponse<TestContext>) -> Self {
-        // TODO(SYNC): check that values and range are consistent
         Self {
-            height: *response.range.start(),
+            start_height: response.start_height,
             value: response
                 .values
                 .into_iter()
@@ -272,11 +271,8 @@ impl From<ValueResponse<TestContext>> for ValueRawResponse {
 
 impl From<ValueRawResponse> for ValueResponse<TestContext> {
     fn from(response: ValueRawResponse) -> Self {
-        // If the list of values in the response is empty, then end height is
-        // one less than the start height and the range is empty.
-        let end_height = Height::new(response.height.as_u64() + response.value.len() as u64 - 1);
         Self {
-            range: response.height..=end_height,
+            start_height: response.start_height,
             values: response
                 .value
                 .into_iter()

--- a/code/crates/test/src/codec/json/raw.rs
+++ b/code/crates/test/src/codec/json/raw.rs
@@ -149,7 +149,6 @@ pub struct ValueRawRequest {
 pub struct BatchRawRequest {
     pub from: Height,
     pub to: Height,
-    pub max_response_size: usize,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -167,7 +166,6 @@ impl From<Request<TestContext>> for RawRequest {
             Request::BatchRequest(batch_request) => Self::BatchSyncRequest(BatchRawRequest {
                 from: *batch_request.range.start(),
                 to: *batch_request.range.end(),
-                max_response_size: batch_request.max_response_size,
             }),
         }
     }
@@ -181,7 +179,6 @@ impl From<RawRequest> for Request<TestContext> {
             }),
             RawRequest::BatchSyncRequest(batch_raw_request) => Self::BatchRequest(BatchRequest {
                 range: batch_raw_request.from..=batch_raw_request.to,
-                max_response_size: batch_raw_request.max_response_size,
             }),
         }
     }

--- a/code/crates/test/src/codec/json/raw.rs
+++ b/code/crates/test/src/codec/json/raw.rs
@@ -224,12 +224,6 @@ pub struct RawSyncedValue {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct RawBatchSyncValue {
-    pub height: Height,
-    pub value: Option<RawSyncedValue>,
-}
-
-#[derive(Serialize, Deserialize)]
 pub struct ValueRawResponse {
     pub height: Height,
     pub block: Option<RawSyncedValue>,
@@ -290,40 +284,35 @@ impl From<ValueRawResponse> for ValueResponse<TestContext> {
 
 #[derive(Serialize, Deserialize)]
 pub struct BatchRawResponse {
-    pub from: Height,
-    pub to: Height,
-    pub values: Vec<RawBatchSyncValue>,
+    pub height: Height,
+    pub values: Vec<RawSyncedValue>,
 }
 
 impl From<BatchResponse<TestContext>> for BatchRawResponse {
-    fn from(value: BatchResponse<TestContext>) -> Self {
+    fn from(response: BatchResponse<TestContext>) -> Self {
         Self {
-            from: *value.range.start(),
-            to: *value.range.end(),
-            values: value
+            height: *response.range.start(),
+            values: response
                 .values
                 .into_iter()
-                .map(|(height, value)| RawBatchSyncValue {
-                    height,
-                    value: value.map(|block| RawSyncedValue {
-                        value_bytes: block.value_bytes,
-                        certificate: RawCommitCertificate {
-                            height: block.certificate.height,
-                            round: block.certificate.round,
-                            value_id: block.certificate.value_id,
-                            commit_signatures: RawCommitSignatures {
-                                signatures: block
-                                    .certificate
-                                    .commit_signatures
-                                    .iter()
-                                    .map(|sig| RawCommitSignature {
-                                        address: sig.address,
-                                        signature: *sig.signature.inner(),
-                                    })
-                                    .collect(),
-                            },
+                .map(|value| RawSyncedValue {
+                    value_bytes: value.value_bytes,
+                    certificate: RawCommitCertificate {
+                        height: value.certificate.height,
+                        round: value.certificate.round,
+                        value_id: value.certificate.value_id,
+                        commit_signatures: RawCommitSignatures {
+                            signatures: value
+                                .certificate
+                                .commit_signatures
+                                .iter()
+                                .map(|sig| RawCommitSignature {
+                                    address: sig.address,
+                                    signature: *sig.signature.inner(),
+                                })
+                                .collect(),
                         },
-                    }),
+                    },
                 })
                 .collect(),
         }
@@ -331,34 +320,32 @@ impl From<BatchResponse<TestContext>> for BatchRawResponse {
 }
 
 impl From<BatchRawResponse> for BatchResponse<TestContext> {
-    fn from(value: BatchRawResponse) -> Self {
+    fn from(response: BatchRawResponse) -> Self {
         Self {
-            range: RangeInclusive::new(value.from, value.to),
-            values: value
+            range: RangeInclusive::new(
+                response.height,
+                Height::new(response.height.as_u64() + response.values.len() as u64 - 1),
+            ),
+            values: response
                 .values
                 .into_iter()
-                .map(|block| {
-                    (
-                        block.height,
-                        block.value.map(|value| RawDecidedValue {
-                            value_bytes: value.value_bytes,
-                            certificate: CommitCertificate {
-                                height: value.certificate.height,
-                                round: value.certificate.round,
-                                value_id: value.certificate.value_id,
-                                commit_signatures: value
-                                    .certificate
-                                    .commit_signatures
-                                    .signatures
-                                    .iter()
-                                    .map(|sig| CommitSignature {
-                                        address: sig.address,
-                                        signature: sig.signature.into(),
-                                    })
-                                    .collect(),
-                            },
-                        }),
-                    )
+                .map(|value| RawDecidedValue {
+                    value_bytes: value.value_bytes,
+                    certificate: CommitCertificate {
+                        height: value.certificate.height,
+                        round: value.certificate.round,
+                        value_id: value.certificate.value_id,
+                        commit_signatures: value
+                            .certificate
+                            .commit_signatures
+                            .signatures
+                            .iter()
+                            .map(|sig| CommitSignature {
+                                address: sig.address,
+                                signature: sig.signature.into(),
+                            })
+                            .collect(),
+                    },
                 })
                 .collect(),
         }

--- a/code/crates/test/src/codec/proto/mod.rs
+++ b/code/crates/test/src/codec/proto/mod.rs
@@ -363,9 +363,6 @@ impl Codec<sync::Request<TestContext>> for ProtobufCodec {
                 }
                 Some(end_height) => Ok(sync::Request::BatchRequest(sync::BatchRequest::new(
                     RangeInclusive::new(Height::new(req.height), Height::new(end_height)),
-                    req.max_response_size.ok_or_else(|| {
-                        ProtoError::invalid_data::<proto::SyncRequest>("max_response_size")
-                    })? as usize,
                 ))),
                 None => Ok(sync::Request::ValueRequest(sync::ValueRequest::new(
                     Height::new(req.height),
@@ -381,7 +378,6 @@ impl Codec<sync::Request<TestContext>> for ProtobufCodec {
                     proto::ValueRequest {
                         height: req.height.as_u64(),
                         end_height: None,
-                        max_response_size: None,
                     },
                 )),
             },
@@ -390,7 +386,6 @@ impl Codec<sync::Request<TestContext>> for ProtobufCodec {
                     proto::ValueRequest {
                         height: req.range.start().as_u64(),
                         end_height: Some(req.range.end().as_u64()),
-                        max_response_size: Some(req.max_response_size as u64),
                     },
                 )),
             },

--- a/code/crates/test/src/codec/proto/mod.rs
+++ b/code/crates/test/src/codec/proto/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::ops::RangeInclusive;
 
 use bytes::Bytes;
@@ -358,15 +357,23 @@ impl Codec<sync::Request<TestContext>> for ProtobufCodec {
             .ok_or_else(|| ProtoError::missing_field::<proto::SyncRequest>("request"))?;
 
         match request {
-            proto::sync_request::Request::ValueRequest(req) => Ok(sync::Request::ValueRequest(
-                sync::ValueRequest::new(Height::new(req.height)),
-            )),
-            proto::sync_request::Request::BatchRequest(req) => {
-                Ok(sync::Request::BatchRequest(sync::BatchRequest::new(
-                    RangeInclusive::new(Height::new(req.from_height), Height::new(req.to_height)),
-                    req.max_response_size as usize,
-                )))
-            }
+            proto::sync_request::Request::ValueRequest(req) => match req.end_height {
+                Some(end_height) => {
+                    if end_height > req.height {
+                        Ok(sync::Request::BatchRequest(sync::BatchRequest::new(
+                            RangeInclusive::new(Height::new(req.height), Height::new(end_height)),
+                            req.max_response_size.ok_or_else(|| {
+                                ProtoError::invalid_data::<proto::SyncRequest>("max_response_size")
+                            })? as usize,
+                        )))
+                    } else {
+                        Err(ProtoError::invalid_data::<proto::SyncRequest>("end_height"))
+                    }
+                }
+                None => Ok(sync::Request::ValueRequest(sync::ValueRequest::new(
+                    Height::new(req.height),
+                ))),
+            },
         }
     }
 
@@ -376,15 +383,17 @@ impl Codec<sync::Request<TestContext>> for ProtobufCodec {
                 request: Some(proto::sync_request::Request::ValueRequest(
                     proto::ValueRequest {
                         height: req.height.as_u64(),
+                        end_height: None,
+                        max_response_size: None,
                     },
                 )),
             },
             sync::Request::BatchRequest(req) => proto::SyncRequest {
-                request: Some(proto::sync_request::Request::BatchRequest(
-                    proto::BatchRequest {
-                        from_height: req.range.start().as_u64(),
-                        to_height: req.range.end().as_u64(),
-                        max_response_size: req.max_response_size as u64,
+                request: Some(proto::sync_request::Request::ValueRequest(
+                    proto::ValueRequest {
+                        height: req.range.start().as_u64(),
+                        end_height: Some(req.range.end().as_u64()),
+                        max_response_size: Some(req.max_response_size as u64),
                     },
                 )),
             },
@@ -421,18 +430,17 @@ pub fn decode_sync_response(
             ))
         }
         proto::sync_response::Response::BatchResponse(batch_response) => {
-            let mut map = BTreeMap::new();
-            for v in batch_response.values {
-                let height = Height::new(v.height);
-                let value = v.value.map(decode_synced_value).transpose()?;
-                map.insert(height, value);
-            }
+            let values = batch_response
+                .values
+                .iter()
+                .map(|v| decode_synced_value(v.clone()))
+                .collect::<Result<Vec<_>, ProtoError>>()?;
             sync::Response::BatchResponse(sync::BatchResponse::new(
                 RangeInclusive::new(
-                    Height::new(batch_response.from_height),
-                    Height::new(batch_response.to_height),
+                    Height::new(batch_response.height),
+                    Height::new(batch_response.height + batch_response.values.len() as u64 - 1),
                 ),
-                map,
+                values,
             ))
         }
     };
@@ -459,22 +467,11 @@ pub fn encode_sync_response(
         sync::Response::BatchResponse(batch_response) => proto::SyncResponse {
             response: Some(proto::sync_response::Response::BatchResponse(
                 proto::BatchResponse {
-                    from_height: batch_response.range.start().as_u64(),
-                    to_height: batch_response.range.end().as_u64(),
+                    height: batch_response.range.start().as_u64(),
                     values: batch_response
                         .values
                         .iter()
-                        .map(
-                            |(height, value)| -> Result<proto::BatchSyncValue, ProtoError> {
-                                Ok(proto::BatchSyncValue {
-                                    height: height.as_u64(),
-                                    value: value
-                                        .clone()
-                                        .map(|v| encode_synced_value(&v))
-                                        .transpose()?,
-                                })
-                            },
-                        )
+                        .map(encode_synced_value)
                         .collect::<Result<Vec<_>, ProtoError>>()?,
                 },
             )),

--- a/code/crates/test/src/codec/proto/mod.rs
+++ b/code/crates/test/src/codec/proto/mod.rs
@@ -403,13 +403,10 @@ pub fn decode_sync_response(
 
     let response = match response {
         proto::sync_response::Response::ValueResponse(response) => {
-            // When the list of values is empty, the end height is smaller than
-            // the start height and the range is empty.
-            let end_height = Height::new(response.height + response.value.len() as u64 - 1);
             sync::Response::ValueResponse(sync::ValueResponse::new(
-                Height::new(response.height)..=end_height,
+                Height::new(response.start_height),
                 response
-                    .value
+                    .values
                     .into_iter()
                     .map(decode_synced_value)
                     .collect::<Result<Vec<_>, ProtoError>>()?,
@@ -427,8 +424,8 @@ pub fn encode_sync_response(
         sync::Response::ValueResponse(value_response) => proto::SyncResponse {
             response: Some({
                 proto::sync_response::Response::ValueResponse(proto::ValueResponse {
-                    height: value_response.range.start().as_u64(),
-                    value: value_response
+                    start_height: value_response.start_height.as_u64(),
+                    values: value_response
                         .values
                         .iter()
                         .map(encode_synced_value)

--- a/code/examples/channel/src/app.rs
+++ b/code/examples/channel/src/app.rs
@@ -290,8 +290,8 @@ pub async fn run(state: &mut State, channels: &mut Channels<TestContext>) -> eyr
                 let raw_decided_values: Vec<RawDecidedValue<TestContext>> = decided_values
                     .into_iter()
                     .map(|decided_value| RawDecidedValue {
-                        certificate: decided_value.certificate,
                         value_bytes: encode_value(&decided_value.value),
+                        certificate: decided_value.certificate,
                     })
                     .collect();
 

--- a/code/examples/channel/src/app.rs
+++ b/code/examples/channel/src/app.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::time::Duration;
 
 use eyre::eyre;
@@ -288,19 +287,13 @@ pub async fn run(state: &mut State, channels: &mut Channels<TestContext>) -> eyr
                 let decided_values = state.get_decided_values(range.clone()).await;
                 info!(from = %range.start(), to = %range.end(), "Found decided values: {decided_values:?}");
 
-                let raw_decided_values: BTreeMap<Height, Option<RawDecidedValue<TestContext>>> =
-                    decided_values
-                        .into_iter()
-                        .map(|(height, decided_value)| {
-                            (
-                                height,
-                                Some(RawDecidedValue {
-                                    certificate: decided_value.certificate,
-                                    value_bytes: encode_value(&decided_value.value),
-                                }),
-                            )
-                        })
-                        .collect();
+                let raw_decided_values: Vec<RawDecidedValue<TestContext>> = decided_values
+                    .into_iter()
+                    .map(|decided_value| RawDecidedValue {
+                        certificate: decided_value.certificate,
+                        value_bytes: encode_value(&decided_value.value),
+                    })
+                    .collect();
 
                 if reply.send(raw_decided_values).is_err() {
                     error!("Failed to send GetDecidedValues reply");

--- a/code/examples/channel/src/app.rs
+++ b/code/examples/channel/src/app.rs
@@ -261,26 +261,10 @@ pub async fn run(state: &mut State, channels: &mut Channels<TestContext>) -> eyr
             }
 
             // If, on the other hand, we are not lagging behind but are instead asked by one of
-            // our peer to help them catch up because they are the one lagging behind,
-            // then the engine might ask the application to provide with the value
-            // that was decided at some lower height. In that case, we fetch it from our store
-            // and send it to consensus.
-            AppMsg::GetDecidedValue { height, reply } => {
-                info!(%height, "Received sync request for decided value");
-
-                let decided_value = state.get_decided_value(height).await;
-                info!(%height, "Found decided value: {decided_value:?}");
-
-                let raw_decided_value = decided_value.map(|decided_value| RawDecidedValue {
-                    certificate: decided_value.certificate,
-                    value_bytes: encode_value(&decided_value.value),
-                });
-
-                if reply.send(raw_decided_value).is_err() {
-                    error!("Failed to send GetDecidedValue reply");
-                }
-            }
-
+            // our peers to help them catch up because they are the one lagging behind,
+            // then the engine might ask the application to provide with the values
+            // that were decided at some lower heights. In that case, we fetch them from our store
+            // and send them to consensus.
             AppMsg::GetDecidedValues { range, reply } => {
                 info!(from = %range.start(), to = %range.end(), "Received sync request for decided values");
 

--- a/code/examples/channel/src/state.rs
+++ b/code/examples/channel/src/state.rs
@@ -1,7 +1,7 @@
 //! Internal state of the application. This is a simplified abstract to keep it simple.
 //! A regular application would have mempool implemented, a proper database and input methods like RPC.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use std::time::Duration;
 
@@ -187,10 +187,7 @@ impl State {
     }
 
     /// Retrieves decided values in the specified range.
-    pub async fn get_decided_values(
-        &self,
-        range: RangeInclusive<Height>,
-    ) -> BTreeMap<Height, DecidedValue> {
+    pub async fn get_decided_values(&self, range: RangeInclusive<Height>) -> Vec<DecidedValue> {
         self.store
             .get_decided_values(range)
             .await

--- a/code/examples/channel/src/state.rs
+++ b/code/examples/channel/src/state.rs
@@ -181,11 +181,6 @@ impl State {
         Ok(Some(value))
     }
 
-    /// Retrieves a decided block at the given height
-    pub async fn get_decided_value(&self, height: Height) -> Option<DecidedValue> {
-        self.store.get_decided_value(height).await.ok().flatten()
-    }
-
     /// Retrieves decided values in the specified range.
     pub async fn get_decided_values(&self, range: RangeInclusive<Height>) -> Vec<DecidedValue> {
         self.store

--- a/code/examples/channel/src/store.rs
+++ b/code/examples/channel/src/store.rs
@@ -373,17 +373,6 @@ impl Store {
             .flatten()
     }
 
-    /// Retrieves a decided value for the given height.
-    /// Called by the application when a syncing peer is asking for a decided value.
-    pub async fn get_decided_value(
-        &self,
-        height: Height,
-    ) -> Result<Option<DecidedValue>, StoreError> {
-        let db = Arc::clone(&self.db);
-
-        tokio::task::spawn_blocking(move || db.get_decided_value(height)).await?
-    }
-
     /// Retrieves decided values for a range of heights.
     /// Called by the application when a syncing peer is asking for a batch of decided values.
     pub async fn get_decided_values(

--- a/code/examples/channel/src/store.rs
+++ b/code/examples/channel/src/store.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::mem::size_of;
 use std::ops::RangeInclusive;
 use std::path::Path;
@@ -390,25 +389,16 @@ impl Store {
     pub async fn get_decided_values(
         &self,
         range: RangeInclusive<Height>,
-    ) -> Result<BTreeMap<Height, DecidedValue>, StoreError> {
+    ) -> Result<Vec<DecidedValue>, StoreError> {
         let db = Arc::clone(&self.db);
         tokio::task::spawn_blocking(move || {
-            let mut values = BTreeMap::new();
-
             // TODO: optimize this to avoid multiple database reads
 
-            let mut height = *range.start();
-            loop {
-                if let Some(value) = db.get_decided_value(height)? {
-                    values.insert(height, value);
-                } else {
-                    break;
+            let mut values = Vec::new();
+            for h in range.start().as_u64()..=range.end().as_u64() {
+                if let Some(value) = db.get_decided_value(Height::new(h))? {
+                    values.push(value);
                 }
-
-                if height >= *range.end() {
-                    break;
-                }
-                height = height.increment();
             }
             Ok(values)
         })


### PR DESCRIPTION
Main changes:
- app interface: in `HostMsg` remove `GetDecidedValue` and keep only `GetDecidedValues`
- proto definitions: remove `BatchResponse` message and consolidate all responses in `ValueResponse`