### PR TITLE
fix(code): Don't pass the sync response to the app when the commit certificate is invalid

### DIFF
--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -507,6 +507,8 @@ where
                                         )
                                     })?;
                             }
+
+                            return Ok(());
                         }
 
                         self.host.call_and_forward(


### PR DESCRIPTION
Fix the code not to pass the value response in case the commit certificate associated with it is invalid. 

### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
