### PR TITLE
fix(QA): Remove branch option from the workflow as it already exists by default on git.

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -20,13 +20,9 @@ on:
           - "5"
           - "10"
           - "15"
-      branch:
-        description: "Git branch to use"
-        required: true
-        default: "main"
       publish:
         description: "Upload results to S3 to be published on the Malachite website dashboard"
-        required: false
+        required: true
         default: "false"
         type: choice
         options:
@@ -41,14 +37,13 @@ jobs:
       TF_VAR_ssh_keys: '["${{ secrets.DO_SSH_FINGERPRINT }}"]'
       EXPR_SETUP: "${{ github.event.inputs.setup }}"
       EXPR_DURATION_MINUTES: "${{ github.event.inputs.expr_duration }}"
-      BRANCH: "${{ github.event.inputs.branch }}"
       PUBLISH: "${{ github.event.inputs.publish }}"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.BRANCH }}
+          ref: ${{ github.ref }}
 
       - name: Set up SSH agent
         uses: webfactory/ssh-agent@v0.9.0


### PR DESCRIPTION


This PR removes the option where we define the specific branch of the codebase the workflow will use when deploying Malachite, as it already exists in GitHub by default. 

### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
