### PR TITLE
fix(qa): Revert the commit where we removed the branch option from the QA.

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -20,9 +20,13 @@ on:
           - "5"
           - "10"
           - "15"
+      branch:
+        description: "Git branch to use"
+        required: true
+        default: "main"
       publish:
         description: "Upload results to S3 to be published on the Malachite website dashboard"
-        required: true
+        required: false
         default: "false"
         type: choice
         options:
@@ -37,13 +41,14 @@ jobs:
       TF_VAR_ssh_keys: '["${{ secrets.DO_SSH_FINGERPRINT }}"]'
       EXPR_SETUP: "${{ github.event.inputs.setup }}"
       EXPR_DURATION_MINUTES: "${{ github.event.inputs.expr_duration }}"
+      BRANCH: "${{ github.event.inputs.branch }}"
       PUBLISH: "${{ github.event.inputs.publish }}"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ env.BRANCH }}
 
       - name: Set up SSH agent
         uses: webfactory/ssh-agent@v0.9.0


### PR DESCRIPTION
This reverts commit 100350859fd6ca4bd115f3eb97a7f04c6b8179ee. Mainly, the default branch option on GitHub is not enough as it points to the branch of the workflow, and we need to run the workflow from the main branch, but using the code from another branch.



### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
