### PR TITLE
feat(qa): Run QA experiments multiple times and publish the average results

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -43,9 +43,9 @@ jobs:
       TF_VAR_do_token: "${{ secrets.DO_TOKEN }}"
       TF_VAR_ssh_keys: '["${{ secrets.DO_SSH_FINGERPRINT }}"]'
       EXPR_SETUP: "${{ github.event.inputs.setup || 'north-america' }}"
-      EXPR_DURATION_MINUTES: "${{ github.event.inputs.expr_duration || '15' }}"
+      EXPR_DURATION_MINUTES: "${{ github.event.inputs.expr_duration || '3' }}"
       BRANCH: "${{ github.event.inputs.branch || 'nenad/run-qa-multiple-times' }}"
-      PUBLISH: "${{ github.event.inputs.publish || 'true' }}"
+      PUBLISH: "${{ github.event.inputs.publish || 'false' }}"
       RUNS: "${{ github.event.inputs.runs || '2' }}"
 
     steps:
@@ -110,9 +110,10 @@ jobs:
       - name: Run experiment multiple times
         working-directory: qa/terraform
         run: |
+          terraform init
           for i in $(seq 1 $RUNS); do
             echo ">>> Starting run $i"
-            terraform init
+           
             terraform apply -auto-approve
 
             shopt -s expand_aliases

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -25,13 +25,24 @@ on:
         required: true
         default: "main"
       publish:
-        description: "Upload results to S3 to be published on the Malachite website dashboard"
+        description: "Publish results to the Malachite website?"
         required: false
         default: "false"
         type: choice
         options:
           - "true"
           - "false"
+      runs:
+        description: "Number of times to run the experiment"
+        required: false
+        default: "1"
+        type: choice
+        options:
+          - "1"
+          - "2"
+          - "3"
+          - "4"
+          - "5"
 
 jobs:
   run-malachite-do:
@@ -43,6 +54,7 @@ jobs:
       EXPR_DURATION_MINUTES: "${{ github.event.inputs.expr_duration }}"
       BRANCH: "${{ github.event.inputs.branch }}"
       PUBLISH: "${{ github.event.inputs.publish }}"
+      RUNS: "${{ github.event.inputs.runs }}"
 
     steps:
       - name: Checkout code
@@ -89,37 +101,7 @@ jobs:
             exit 1
           fi
 
-      - name: Terraform Init
-        working-directory: qa/terraform
-        run: terraform init
-
-      - name: Terraform Apply (Provision Nodes)
-        working-directory: qa/terraform
-        run: terraform apply -auto-approve
-
-      - name: Deploy application and run it
-        working-directory: qa/terraform
-        run: |
-          shopt -s expand_aliases
-          source commands.sh
-          mkdir -p "$HOME/.ssh"
-          touch "$HOME/.ssh/known_hosts"
-          deploy_cc 
-          setup_config
-          d_pull all
-          d_run all
-          EXPR_DURATION=$((EXPR_DURATION_MINUTES * 60))
-          sleep "$EXPR_DURATION"
-          _export_prometheus_performance_csv
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Define filename suffix
+      - name: Define experiment metadata
         id: vars
         run: |
           if [[ "$EXPR_SETUP" == "north-america" ]]; then
@@ -128,34 +110,74 @@ jobs:
             SETUP="global"
           fi
           DATE=$(date +%Y.%m.%d)
+          TIME=$(date +%H-%M-%S)
+          EXPERIMENT_ID="${DATE}-${TIME}"
           echo "setup=$SETUP" >> $GITHUB_OUTPUT
-          echo "date=$DATE" >> $GITHUB_OUTPUT
-          echo "suffix=-${SETUP}-${DATE}.csv" >> $GITHUB_OUTPUT
-        env:
-          EXPR_SETUP: ${{ env.EXPR_SETUP }}
+          echo "experiment_id=$EXPERIMENT_ID" >> $GITHUB_OUTPUT
 
-      - name: Upload raw CSVs to S3
+      - name: Run experiment multiple times
         working-directory: qa/terraform
         run: |
-          SUFFIX=${{ steps.vars.outputs.suffix }}
-          aws s3 cp latency.csv s3://malachite-performance-site/raw/$EXPR_SETUP/latency${SUFFIX}
-          aws s3 cp throughput.csv s3://malachite-performance-site/raw/$EXPR_SETUP/throughput${SUFFIX}
-          aws s3 cp block-time.csv s3://malachite-performance-site/raw/$EXPR_SETUP/block-time${SUFFIX}
+          for i in $(seq 1 $RUNS); do
+            echo ">>> Starting run $i"
+            terraform init
+            terraform apply -auto-approve
+
+            shopt -s expand_aliases
+            source commands.sh
+            mkdir -p "$HOME/.ssh"
+            touch "$HOME/.ssh/known_hosts"
+
+            deploy_cc 
+            setup_config
+            d_pull all
+            d_run all
+
+            EXPR_DURATION=$((EXPR_DURATION_MINUTES * 60))
+            sleep "$EXPR_DURATION"
+
+            _export_prometheus_performance_csv
+
+            mv latency.csv latency_run_${i}.csv
+            mv throughput.csv throughput_run_${i}.csv
+            mv block-time.csv block-time_run_${i}.csv
+
+            terraform destroy -auto-approve
+          done
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload all run CSVs to S3
+        working-directory: qa/terraform
+        run: |
+          SETUP=${{ steps.vars.outputs.setup }}
+          EXPERIMENT_ID=${{ steps.vars.outputs.experiment_id }}
+
+          for i in $(seq 1 $RUNS); do
+            aws s3 cp latency_run${i}.csv s3://malachite-performance-site/raw/$SETUP/$EXPERIMENT_ID/latency_run_${i}.csv
+            aws s3 cp throughput_run${i}.csv s3://malachite-performance-site/raw/$SETUP/$EXPERIMENT_ID/throughput_run_${i}.csv
+            aws s3 cp block-time_run${i}.csv s3://malachite-performance-site/raw/$SETUP/$EXPERIMENT_ID/block-time_run_${i}.csv
+          done
 
       - name: Format block-time and throughput CSVs
         if: ${{ env.PUBLISH == 'true' }}
         working-directory: qa/terraform
         run: |
-          python3 scripts/format_csv_file.py block-time.csv --type block-time
-          python3 scripts/format_csv_file.py throughput.csv --type throughput
+          python3 scripts/format_csv_file.py block-time-avg.csv --type block-time
+          python3 scripts/format_csv_file.py throughput-avg.csv --type throughput
 
       - name: Upload formatted CSVs to dashboard folder
         if: ${{ env.PUBLISH == 'true' }}
         working-directory: qa/terraform
         run: |
-          SUFFIX=${{ steps.vars.outputs.suffix }}
-          aws s3 cp block-time.csv s3://malachite-performance-site/dashboard/block-time${SUFFIX}
-          aws s3 cp throughput.csv s3://malachite-performance-site/dashboard/throughput${SUFFIX}
+          SUFFIX="-${{ steps.vars.outputs.setup }}-${{ steps.vars.outputs.experiment_id }}.csv"
+          aws s3 cp block-time-avg.csv s3://malachite-performance-site/dashboard/block-time${SUFFIX}
+          aws s3 cp throughput-avg.csv s3://malachite-performance-site/dashboard/throughput${SUFFIX}
 
       - name: Generate file_list.json for dashboard
         if: ${{ env.PUBLISH == 'true' }}
@@ -183,8 +205,3 @@ jobs:
         working-directory: qa/terraform
         run: |
           aws s3 cp file_list.json s3://malachite-performance-site/dashboard/file_list.json
-
-      - name: Terraform Destroy (Cleanup Nodes)
-        if: always()
-        working-directory: qa/terraform
-        run: terraform destroy -auto-approve

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -8,18 +8,13 @@ on:
         required: true
         default: "north-america"
         type: choice
-        options:
-          - global
-          - north-america
+        options: [global, north-america]
       expr_duration:
         description: "Experiment duration (in minutes)"
         required: true
         default: "15"
         type: choice
-        options:
-          - "5"
-          - "10"
-          - "15"
+        options: ["5", "10", "15"]
       branch:
         description: "Git branch to use"
         required: true
@@ -29,20 +24,17 @@ on:
         required: false
         default: "false"
         type: choice
-        options:
-          - "true"
-          - "false"
+        options: ["true", "false"]
       runs:
         description: "Number of times to repeat the experiment"
         required: false
         default: "1"
         type: choice
-        options:
-          - "1"
-          - "2"
-          - "3"
-          - "4"
-          - "5"
+        options: ["1", "2", "3", "4", "5"]
+  
+  push:
+    branches:
+      - nenad/run-qa-multiple-times
 
 jobs:
   run-malachite-do:
@@ -50,11 +42,11 @@ jobs:
     env:
       TF_VAR_do_token: "${{ secrets.DO_TOKEN }}"
       TF_VAR_ssh_keys: '["${{ secrets.DO_SSH_FINGERPRINT }}"]'
-      EXPR_SETUP: "${{ github.event.inputs.setup }}"
-      EXPR_DURATION_MINUTES: "${{ github.event.inputs.expr_duration }}"
-      BRANCH: "${{ github.event.inputs.branch }}"
-      PUBLISH: "${{ github.event.inputs.publish }}"
-      RUNS: "${{ github.event.inputs.runs }}"
+      EXPR_SETUP: "${{ github.event.inputs.setup || 'north-america' }}"
+      EXPR_DURATION_MINUTES: "${{ github.event.inputs.expr_duration || '15' }}"
+      BRANCH: "${{ github.event.inputs.branch || 'nenad/run-qa-multiple-times' }}"
+      PUBLISH: "${{ github.event.inputs.publish || 'true' }}"
+      RUNS: "${{ github.event.inputs.runs || '2' }}"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -135,6 +135,9 @@ jobs:
             mv block-time.csv block-time_run_${i}.csv
 
             terraform destroy -auto-approve
+            
+            echo "Waiting to make sure Terraform finalized resource deletion..."
+            sleep 30
           done
 
       - name: Configure AWS credentials

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -33,7 +33,7 @@ on:
           - "true"
           - "false"
       runs:
-        description: "Number of times to run the experiment"
+        description: "Number of times to repeat the experiment"
         required: false
         default: "1"
         type: choice
@@ -152,32 +152,37 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Upload all run CSVs to S3
+      - name: Upload raw CSVs from all runs to S3
         working-directory: qa/terraform
         run: |
           SETUP=${{ steps.vars.outputs.setup }}
           EXPERIMENT_ID=${{ steps.vars.outputs.experiment_id }}
 
           for i in $(seq 1 $RUNS); do
-            aws s3 cp latency_run${i}.csv s3://malachite-performance-site/raw/$SETUP/$EXPERIMENT_ID/latency_run_${i}.csv
-            aws s3 cp throughput_run${i}.csv s3://malachite-performance-site/raw/$SETUP/$EXPERIMENT_ID/throughput_run_${i}.csv
-            aws s3 cp block-time_run${i}.csv s3://malachite-performance-site/raw/$SETUP/$EXPERIMENT_ID/block-time_run_${i}.csv
+            aws s3 cp latency_run_${i}.csv s3://malachite-performance-site/raw/$SETUP/$EXPERIMENT_ID/latency_run_${i}.csv
+            aws s3 cp throughput_run_${i}.csv s3://malachite-performance-site/raw/$SETUP/$EXPERIMENT_ID/throughput_run_${i}.csv
+            aws s3 cp block-time_run_${i}.csv s3://malachite-performance-site/raw/$SETUP/$EXPERIMENT_ID/block-time_run_${i}.csv
           done
 
-      - name: Format block-time and throughput CSVs
+      - name: Format and average CSVs across runs
         if: ${{ env.PUBLISH == 'true' }}
         working-directory: qa/terraform
         run: |
-          python3 scripts/format_csv_file.py block-time-avg.csv --type block-time
-          python3 scripts/format_csv_file.py throughput-avg.csv --type throughput
+          for i in $(seq 1 $RUNS); do
+            python3 scripts/format_csv_file.py block-time_run_${i}.csv --type block-time
+            python3 scripts/format_csv_file.py throughput_run_${i}.csv --type throughput
+          done
+
+          python3 scripts/average_run.py block-time_run_*.csv --output block-time.csv
+          python3 scripts/average_run.py throughput_run_*.csv --output throughput.csv
 
       - name: Upload formatted CSVs to dashboard folder
         if: ${{ env.PUBLISH == 'true' }}
         working-directory: qa/terraform
         run: |
           SUFFIX="-${{ steps.vars.outputs.setup }}-${{ steps.vars.outputs.experiment_id }}.csv"
-          aws s3 cp block-time-avg.csv s3://malachite-performance-site/dashboard/block-time${SUFFIX}
-          aws s3 cp throughput-avg.csv s3://malachite-performance-site/dashboard/throughput${SUFFIX}
+          aws s3 cp block-time.csv s3://malachite-performance-site/dashboard/block-time${SUFFIX}
+          aws s3 cp throughput.csv s3://malachite-performance-site/dashboard/throughput${SUFFIX}
 
       - name: Generate file_list.json for dashboard
         if: ${{ env.PUBLISH == 'true' }}

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -14,7 +14,7 @@ on:
         required: true
         default: "15"
         type: choice
-        options: ["5", "10", "15"]
+        options: ["15", "20", "30"]
       branch:
         description: "Git branch to use"
         required: true
@@ -43,7 +43,7 @@ jobs:
       TF_VAR_do_token: "${{ secrets.DO_TOKEN }}"
       TF_VAR_ssh_keys: '["${{ secrets.DO_SSH_FINGERPRINT }}"]'
       EXPR_SETUP: "${{ github.event.inputs.setup || 'north-america' }}"
-      EXPR_DURATION_MINUTES: "${{ github.event.inputs.expr_duration || '3' }}"
+      EXPR_DURATION_MINUTES: "${{ github.event.inputs.expr_duration || '5' }}"
       BRANCH: "${{ github.event.inputs.branch || 'nenad/run-qa-multiple-times' }}"
       PUBLISH: "${{ github.event.inputs.publish || 'true' }}"
       RUNS: "${{ github.event.inputs.runs || '2' }}"

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -16,7 +16,7 @@ on:
         type: choice
         options: ["15", "20", "30"]
       branch:
-        description: "Git branch to use"
+        description: "Git branch or tag to use"
         required: true
         default: "main"
       publish:
@@ -31,10 +31,6 @@ on:
         default: "1"
         type: choice
         options: ["1", "2", "3", "4", "5"]
-  
-  push:
-    branches:
-      - nenad/run-qa-multiple-times
 
 jobs:
   run-malachite-do:
@@ -42,11 +38,11 @@ jobs:
     env:
       TF_VAR_do_token: "${{ secrets.DO_TOKEN }}"
       TF_VAR_ssh_keys: '["${{ secrets.DO_SSH_FINGERPRINT }}"]'
-      EXPR_SETUP: "${{ github.event.inputs.setup || 'north-america' }}"
-      EXPR_DURATION_MINUTES: "${{ github.event.inputs.expr_duration || '5' }}"
-      BRANCH: "${{ github.event.inputs.branch || 'nenad/run-qa-multiple-times' }}"
-      PUBLISH: "${{ github.event.inputs.publish || 'true' }}"
-      RUNS: "${{ github.event.inputs.runs || '2' }}"
+      EXPR_SETUP: "${{ github.event.inputs.setup }}"
+      EXPR_DURATION_MINUTES: "${{ github.event.inputs.expr_duration }}"
+      BRANCH: "${{ github.event.inputs.branch }}"
+      PUBLISH: "${{ github.event.inputs.publish }}"
+      RUNS: "${{ github.event.inputs.runs }}"
 
     steps:
       - name: Checkout code
@@ -103,9 +99,12 @@ jobs:
           fi
           DATE=$(date +%Y.%m.%d)
           TIME=$(date +%H-%M-%S)
+          BRANCH_CLEANED=$(echo "$BRANCH" | sed 's|/|-|g')
           EXPERIMENT_ID="${DATE}-${TIME}"
+          SUFFIX="-${SETUP}-${BRANCH_CLEANED}-${EXPERIMENT_ID}.csv"
           echo "setup=$SETUP" >> $GITHUB_OUTPUT
           echo "experiment_id=$EXPERIMENT_ID" >> $GITHUB_OUTPUT
+          echo "suffix=$SUFFIX" >> $GITHUB_OUTPUT
 
       - name: Run experiment multiple times
         working-directory: qa/terraform
@@ -136,7 +135,6 @@ jobs:
             mv block-time.csv block-time_run_${i}.csv
 
             terraform destroy -auto-approve
-            
             echo "Waiting to make sure Terraform finalized resource deletion..."
             sleep 30
           done
@@ -153,7 +151,6 @@ jobs:
         run: |
           SETUP=${{ steps.vars.outputs.setup }}
           EXPERIMENT_ID=${{ steps.vars.outputs.experiment_id }}
-
           for i in $(seq 1 $RUNS); do
             aws s3 cp latency_run_${i}.csv s3://malachite-performance-site/raw/$SETUP/$EXPERIMENT_ID/latency_run_${i}.csv
             aws s3 cp throughput_run_${i}.csv s3://malachite-performance-site/raw/$SETUP/$EXPERIMENT_ID/throughput_run_${i}.csv
@@ -168,7 +165,6 @@ jobs:
             python3 scripts/format_csv_file.py block-time_run_${i}.csv --type block-time
             python3 scripts/format_csv_file.py throughput_run_${i}.csv --type throughput
           done
-
           python3 scripts/average_runs.py block-time_run_*.csv --output block-time.csv
           python3 scripts/average_runs.py throughput_run_*.csv --output throughput.csv
 
@@ -176,7 +172,7 @@ jobs:
         if: ${{ env.PUBLISH == 'true' }}
         working-directory: qa/terraform
         run: |
-          SUFFIX="-${{ steps.vars.outputs.setup }}-${{ steps.vars.outputs.experiment_id }}.csv"
+          SUFFIX="${{ steps.vars.outputs.suffix }}"
           aws s3 cp block-time.csv s3://malachite-performance-site/dashboard/block-time${SUFFIX}
           aws s3 cp throughput.csv s3://malachite-performance-site/dashboard/throughput${SUFFIX}
 

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -169,8 +169,8 @@ jobs:
             python3 scripts/format_csv_file.py throughput_run_${i}.csv --type throughput
           done
 
-          python3 scripts/average_run.py block-time_run_*.csv --output block-time.csv
-          python3 scripts/average_run.py throughput_run_*.csv --output throughput.csv
+          python3 scripts/average_runs.py block-time_run_*.csv --output block-time.csv
+          python3 scripts/average_runs.py throughput_run_*.csv --output throughput.csv
 
       - name: Upload formatted CSVs to dashboard folder
         if: ${{ env.PUBLISH == 'true' }}

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -45,7 +45,7 @@ jobs:
       EXPR_SETUP: "${{ github.event.inputs.setup || 'north-america' }}"
       EXPR_DURATION_MINUTES: "${{ github.event.inputs.expr_duration || '3' }}"
       BRANCH: "${{ github.event.inputs.branch || 'nenad/run-qa-multiple-times' }}"
-      PUBLISH: "${{ github.event.inputs.publish || 'false' }}"
+      PUBLISH: "${{ github.event.inputs.publish || 'true' }}"
       RUNS: "${{ github.event.inputs.runs || '2' }}"
 
     steps:

--- a/qa/terraform/project.tf
+++ b/qa/terraform/project.tf
@@ -1,24 +1,8 @@
 resource "digitalocean_project" "malachite-testnet" {
-  name        = var.project_name
+  name = var.project_name
   description = "A project to test the Malachite codebase."
-
-  lifecycle {
-    prevent_destroy = true
-  }
-
   resources = concat([
-    for node in concat(
-      digitalocean_droplet.ams3,
-      digitalocean_droplet.blr1,
-      digitalocean_droplet.fra1,
-      digitalocean_droplet.lon1,
-      digitalocean_droplet.nyc1,
-      digitalocean_droplet.nyc3,
-      digitalocean_droplet.sfo2,
-      digitalocean_droplet.sfo3,
-      digitalocean_droplet.sgp1,
-      digitalocean_droplet.syd1,
-      digitalocean_droplet.tor1
-    ) : node.urn
+    for node in concat(digitalocean_droplet.ams3, digitalocean_droplet.blr1, digitalocean_droplet.fra1, digitalocean_droplet.lon1, digitalocean_droplet.nyc1, digitalocean_droplet.nyc3, digitalocean_droplet.sfo2, digitalocean_droplet.sfo3, digitalocean_droplet.sgp1, digitalocean_droplet.syd1, digitalocean_droplet.tor1) :
+    node.urn
   ], [digitalocean_droplet.cc.urn])
 }

--- a/qa/terraform/project.tf
+++ b/qa/terraform/project.tf
@@ -1,8 +1,24 @@
 resource "digitalocean_project" "malachite-testnet" {
-  name = var.project_name
+  name        = var.project_name
   description = "A project to test the Malachite codebase."
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
   resources = concat([
-    for node in concat(digitalocean_droplet.ams3, digitalocean_droplet.blr1, digitalocean_droplet.fra1, digitalocean_droplet.lon1, digitalocean_droplet.nyc1, digitalocean_droplet.nyc3, digitalocean_droplet.sfo2, digitalocean_droplet.sfo3, digitalocean_droplet.sgp1, digitalocean_droplet.syd1, digitalocean_droplet.tor1) :
-    node.urn
+    for node in concat(
+      digitalocean_droplet.ams3,
+      digitalocean_droplet.blr1,
+      digitalocean_droplet.fra1,
+      digitalocean_droplet.lon1,
+      digitalocean_droplet.nyc1,
+      digitalocean_droplet.nyc3,
+      digitalocean_droplet.sfo2,
+      digitalocean_droplet.sfo3,
+      digitalocean_droplet.sgp1,
+      digitalocean_droplet.syd1,
+      digitalocean_droplet.tor1
+    ) : node.urn
   ], [digitalocean_droplet.cc.urn])
 }

--- a/qa/terraform/scripts/average_runs.py
+++ b/qa/terraform/scripts/average_runs.py
@@ -1,0 +1,38 @@
+# calculate_average.py
+
+import argparse
+import pandas as pd
+import sys
+
+def average_csv_files(input_files, output_file):
+    if len(input_files) == 1:
+        df = pd.read_csv(input_files[0], header=None)
+        df.to_csv(output_file, index=False, header=False)
+        print(f"[✔] Only one file provided — copied directly to {output_file}")
+        return
+
+    dfs = [pd.read_csv(f, header=None) for f in input_files]
+
+    base = dfs[0].iloc[:, :2]
+    for i, df in enumerate(dfs[1:], start=2):
+        if not base.equals(df.iloc[:, :2]):
+            raise ValueError(f"Mismatch in columns 0 and 1 between file 1 and file {i}.")
+
+    values = [df.iloc[:, 2] for df in dfs]
+    avg = sum(values) / len(values)
+
+    result = dfs[0].copy()
+    result.iloc[:, 2] = avg.round().astype(int)
+    result.to_csv(output_file, index=False, header=False)
+    print(f"[✔] Averaged output written to: {output_file}")
+
+def main():
+    parser = argparse.ArgumentParser(description="Average the third column across multiple formatted CSV files.")
+    parser.add_argument("input_files", nargs="+", help="Input CSV files with identical node_name and timestamp")
+    parser.add_argument("--output", required=True, help="Output file for the averaged result")
+    args = parser.parse_args()
+
+    average_csv_files(args.input_files, args.output)
+
+if __name__ == "__main__":
+    main()

--- a/qa/terraform/scripts/average_runs_test.py
+++ b/qa/terraform/scripts/average_runs_test.py
@@ -1,0 +1,48 @@
+import unittest
+import pandas as pd
+import tempfile
+import os
+from average_runs import average_csv_files
+
+class TestAverageCSV(unittest.TestCase):
+    def create_temp_csv(self, rows):
+        tmp = tempfile.NamedTemporaryFile(delete=False, mode='w', suffix=".csv")
+        for row in rows:
+            tmp.write(",".join(map(str, row)) + "\n")
+        tmp.close()
+        return tmp.name
+
+    def test_average_of_three_files(self):
+        rows1 = [["Node1", 0.0, 100], ["Node2", 0.0, 200]]
+        rows2 = [["Node1", 0.0, 110], ["Node2", 0.0, 210]]
+        rows3 = [["Node1", 0.0, 90],  ["Node2", 0.0, 190]]
+
+        files = [self.create_temp_csv(rows) for rows in [rows1, rows2, rows3]]
+        out_file = tempfile.NamedTemporaryFile(delete=False).name
+
+        average_csv_files(files, out_file)
+
+        result = pd.read_csv(out_file, header=None)
+        expected = pd.DataFrame([["Node1", 0.0, 100], ["Node2", 0.0, 200]])
+        pd.testing.assert_frame_equal(result, expected)
+
+        # Cleanup
+        for f in files + [out_file]:
+            os.remove(f)
+
+    def test_single_file_pass_through(self):
+        rows = [["Node1", 0.0, 123], ["Node2", 0.0, 456]]
+        input_file = self.create_temp_csv(rows)
+        output_file = tempfile.NamedTemporaryFile(delete=False).name
+
+        average_csv_files([input_file], output_file)
+        result = pd.read_csv(output_file, header=None)
+        expected = pd.DataFrame(rows)
+
+        pd.testing.assert_frame_equal(result, expected)
+
+        os.remove(input_file)
+        os.remove(output_file)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qa/terraform/scripts/format_csv_file.py
+++ b/qa/terraform/scripts/format_csv_file.py
@@ -13,13 +13,10 @@ def process_throughput(df):
     df['node_name'] = normalize_node_names(df)
     df['timestamp'] = (df['timestamp'] - df['timestamp'].min()) / 60
 
-    # Diagnostics for NaNs
+    # Check for NaNs, can happen if experiment duration is less than 10 minutes 
     print(f"[i] Initial rows: {len(df)}")
     print(f"[i] NaNs in 'throughput': {df['throughput'].isna().sum()}")
-
-    # Drop rows with NaN in throughput
     df = df.dropna(subset=['throughput'])
-
     print(f"[i] Rows after cleaning: {len(df)}")
 
     df['throughput'] = df['throughput'].astype(int)
@@ -31,13 +28,10 @@ def process_block_time(df):
     df['node_name'] = normalize_node_names(df)
     df['timestamp'] = (df['timestamp'] - df['timestamp'].min()) / 60
 
-    # Diagnostics for NaNs
+    # Check for NaNs, can happen if experiment duration is less than 10 minutes 
     print(f"[i] Initial rows: {len(df)}")
     print(f"[i] NaNs in 'latency': {df['latency'].isna().sum()}")
-
-    # Drop rows with NaN in latency
     df = df.dropna(subset=['latency'])
-
     print(f"[i] Rows after cleaning: {len(df)}")
 
     df['latency'] = (df['latency'] * 1000).astype(int)

--- a/qa/terraform/scripts/format_csv_file.py
+++ b/qa/terraform/scripts/format_csv_file.py
@@ -12,13 +12,34 @@ def process_throughput(df):
     df.columns = ['node_name', 'timestamp', 'throughput']
     df['node_name'] = normalize_node_names(df)
     df['timestamp'] = (df['timestamp'] - df['timestamp'].min()) / 60
+
+    # Diagnostics for NaNs
+    print(f"[i] Initial rows: {len(df)}")
+    print(f"[i] NaNs in 'throughput': {df['throughput'].isna().sum()}")
+
+    # Drop rows with NaN in throughput
+    df = df.dropna(subset=['throughput'])
+
+    print(f"[i] Rows after cleaning: {len(df)}")
+
     df['throughput'] = df['throughput'].astype(int)
     return df
+
 
 def process_block_time(df):
     df.columns = ['node_name', 'timestamp', 'latency']
     df['node_name'] = normalize_node_names(df)
     df['timestamp'] = (df['timestamp'] - df['timestamp'].min()) / 60
+
+    # Diagnostics for NaNs
+    print(f"[i] Initial rows: {len(df)}")
+    print(f"[i] NaNs in 'latency': {df['latency'].isna().sum()}")
+
+    # Drop rows with NaN in latency
+    df = df.dropna(subset=['latency'])
+
+    print(f"[i] Rows after cleaning: {len(df)}")
+
     df['latency'] = (df['latency'] * 1000).astype(int)
     return df
 


### PR DESCRIPTION
This PR adds support for running multiple QA experiments (N runs) through the GitHub workflow. Each run is stored individually on S3, and the averaged results are automatically published to the Malachite website dashboard.

### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
