### PR TITLE
fix(code/sync): Use proposer of synced value instead of our own address for `ProcessSyncedValue`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 - Update libp2p to v0.56.x ([#1124](https://github.com/informalsystems/malachite/pull/1124))
 - Rename `Effect::RebroadcastVote` to `Effect::RepublishVote` and `Effect::RebroadcastRoundCertificate` to `Effect::RepublishRoundCertificate` ([#1011](https://github.com/informalsystems/malachite/issues/1011))
 - Decouple `Host` messages from the `Consensus` actor ([#1109](https://github.com/informalsystems/malachite/pull/1109))
+- Fix a bug where values synced from other peers were assigned the current node's address instead of their proposer's address ([#1141](https://github.com/informalsystems/malachite/pull/1141))
 
 ## 0.4.0
 

--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -524,11 +524,19 @@ where
                             return Ok(());
                         }
 
+                        // Fetch the proposer for the round and height of the synced value
+                        // Given that proposer selection is required be fully deterministic,
+                        // we are guaranteed to get the proposer for that value.
+                        let proposer = state
+                            .consensus
+                            .get_proposer(certificate_height, certificate_round)
+                            .clone();
+
                         self.host.call_and_forward(
                             |reply_to| HostMsg::ProcessSyncedValue {
                                 height: certificate_height,
                                 round: certificate_round,
-                                proposer: state.consensus.address().clone(),
+                                proposer,
                                 value_bytes: value.value_bytes,
                                 reply_to,
                             },


### PR DESCRIPTION
Closes: #1135
Part of: https://github.com/informalsystems/malachite/issues/1136

## TODO

- [ ] Write test to reproduce the original issue

---

### PR author checklist

#### For all contributors

- [x] Reference a GitHub issue
- [x] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [x] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
