### PR TITLE
fix(code/sync): Derive the consensus queue capacity from the `sync.parallel_requests` setting

### DIFF
--- a/code/crates/app-channel/src/run.rs
+++ b/code/crates/app-channel/src/run.rs
@@ -70,6 +70,7 @@ where
         address,
         ctx.clone(),
         cfg.consensus().clone(),
+        cfg.value_sync(),
         Box::new(signing_provider),
         network.clone(),
         connector.clone(),

--- a/code/crates/app/src/spawn.rs
+++ b/code/crates/app/src/spawn.rs
@@ -72,7 +72,8 @@ pub async fn spawn_consensus_actor<Ctx>(
     initial_validator_set: Ctx::ValidatorSet,
     address: Ctx::Address,
     ctx: Ctx,
-    cfg: ConsensusConfig,
+    mut cfg: ConsensusConfig,
+    sync_cfg: &ValueSyncConfig,
     signing_provider: Box<dyn SigningProvider<Ctx>>,
     network: NetworkRef<Ctx>,
     host: HostRef<Ctx>,
@@ -99,6 +100,9 @@ where
         threshold_params: Default::default(),
         value_payload,
     };
+
+    // Derive the consensus queue capacity from `sync.parallel_requests`
+    cfg.queue_capacity = sync_cfg.parallel_requests;
 
     Consensus::spawn(
         ctx,

--- a/code/crates/config/src/lib.rs
+++ b/code/crates/config/src/lib.rs
@@ -502,6 +502,11 @@ pub struct ConsensusConfig {
     pub value_payload: ValuePayload,
 
     /// Size of the consensus input queue
+    ///
+    /// # Deprecated
+    /// This setting is deprecated and will be removed in the future.
+    /// The queue capacity is now derived from the `sync.parallel_requests` setting.
+    #[serde(default)]
     pub queue_capacity: usize,
 }
 

--- a/code/crates/starknet/host/src/node.rs
+++ b/code/crates/starknet/host/src/node.rs
@@ -251,7 +251,7 @@ fn make_config(index: usize, total: usize, settings: MakeConfigSettings) -> Conf
         moniker: format!("starknet-{index}"),
         consensus: ConsensusConfig {
             value_payload: ValuePayload::PartsOnly,
-            queue_capacity: 100,
+            queue_capacity: 100, // Deprecated, derived from `sync.parallel_requests`
             timeouts: TimeoutConfig::default(),
             p2p: P2pConfig {
                 protocol: PubSubProtocol::default(),
@@ -347,7 +347,7 @@ fn make_distributed_config(
     Config {
         moniker: format!("starknet-{index}"),
         consensus: ConsensusConfig {
-            queue_capacity: 100,
+            queue_capacity: 100, // Deprecated, derived from `sync.parallel_requests`
             value_payload: ValuePayload::PartsOnly,
             timeouts: TimeoutConfig::default(),
             p2p: P2pConfig {

--- a/code/crates/starknet/host/src/spawn.rs
+++ b/code/crates/starknet/host/src/spawn.rs
@@ -181,7 +181,7 @@ async fn spawn_consensus_actor(
     initial_validator_set: ValidatorSet,
     address: Address,
     ctx: MockContext,
-    cfg: Config,
+    mut cfg: Config,
     signing_provider: Ed25519Provider,
     network: NetworkRef<MockContext>,
     host: HostRef<MockContext>,
@@ -198,6 +198,9 @@ async fn spawn_consensus_actor(
         threshold_params: Default::default(),
         value_payload: ValuePayload::PartsOnly,
     };
+
+    // Derive the consensus queue capacity from `sync.parallel_requests`
+    cfg.consensus.queue_capacity = cfg.value_sync.parallel_requests;
 
     Consensus::spawn(
         ctx,

--- a/code/crates/starknet/test/src/lib.rs
+++ b/code/crates/starknet/test/src/lib.rs
@@ -146,7 +146,7 @@ impl TestRunner {
             logging: LoggingConfig::default(),
             consensus: ConsensusConfig {
                 value_payload: ValuePayload::PartsOnly,
-                queue_capacity: 100,
+                queue_capacity: 100, // Deprecated, derived from `sync.parallel_requests`
                 timeouts: TimeoutConfig::default(),
                 p2p: P2pConfig {
                     protocol,

--- a/code/crates/test/app/config.toml
+++ b/code/crates/test/app/config.toml
@@ -70,10 +70,6 @@ timeout_rebroadcast = "5s"
 # Override with MALACHITE__CONSENSUS__VALUE_PAYLOAD env variable
 value_payload = "parts-only"
 
-# Maximum number of heights to keep in the consensus input buffer.
-# Override with MALACHITE__CONSENSUS__QUEUE_CAPACITY env variable
-queue_capacity = 100
-
 # VoteSync configuration options
 [consensus.vote_sync]
 # The mode of vote synchronization

--- a/code/crates/test/app/src/node.rs
+++ b/code/crates/test/app/src/node.rs
@@ -236,7 +236,7 @@ fn make_config(index: usize, total: usize, settings: MakeConfigSettings) -> Conf
         consensus: ConsensusConfig {
             // Current test app does not support proposal-only value payload properly as Init does not include valid_round
             value_payload: ValuePayload::ProposalAndParts,
-            queue_capacity: 100,
+            queue_capacity: 100, // Deprecated, derived from `sync.parallel_requests`
             timeouts: TimeoutConfig::default(),
             p2p: P2pConfig {
                 protocol: PubSubProtocol::default(),

--- a/code/crates/test/tests/it/main.rs
+++ b/code/crates/test/tests/it/main.rs
@@ -144,7 +144,7 @@ impl TestRunner {
             consensus: ConsensusConfig {
                 // Current test app does not support proposal-only value payload properly as Init does not include valid_round
                 value_payload: ValuePayload::ProposalAndParts,
-                queue_capacity: 100,
+                queue_capacity: 100, // Deprecated, derived from `sync.parallel_requests`
                 timeouts: TimeoutConfig::default(),
                 p2p: P2pConfig {
                     protocol,

--- a/code/examples/channel/config.toml
+++ b/code/examples/channel/config.toml
@@ -69,10 +69,6 @@ timeout_rebroadcast = "5s"
 # Override with MALACHITE__CONSENSUS__VALUE_PAYLOAD env variable
 value_payload = "parts-only"
 
-# Maximum number of heights to keep in the consensus input buffer.
-# Override with MALACHITE__CONSENSUS__QUEUE_CAPACITY env variable
-queue_capacity = 100
-
 # VoteSync configuration options
 [consensus.vote_sync]
 # The mode of vote synchronization

--- a/code/examples/channel/src/node.rs
+++ b/code/examples/channel/src/node.rs
@@ -226,7 +226,7 @@ fn make_config(index: usize, total: usize, settings: MakeConfigSettings) -> Conf
         consensus: ConsensusConfig {
             // Current channel app does not support parts-only value payload properly as Init does not include valid_round
             value_payload: ValuePayload::ProposalAndParts,
-            queue_capacity: 100,
+            queue_capacity: 100, // Deprecated, derived from `sync.parallel_requests`
             timeouts: TimeoutConfig::default(),
             p2p: P2pConfig {
                 protocol: PubSubProtocol::default(),


### PR DESCRIPTION

Part of: #1136 

This is required in order to ensure that consensus inputs yielded by the sync module cannot overflow the queue capacity and therefore dropped

---

### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
