### PR TITLE
fix(qa): Mount source directory as read-write

### DIFF
--- a/qa/docker/Dockerfile
+++ b/qa/docker/Dockerfile
@@ -3,7 +3,7 @@
 FROM rust AS builder
 RUN apt-get update && apt-get install -y protobuf-compiler
 WORKDIR /mnt
-RUN --mount=type=bind,from=code,target=/mnt cargo build --release --target-dir /tmp
+RUN --mount=type=bind,from=code,target=/mnt,rw cargo build --release --target-dir /tmp
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y iproute2


### PR DESCRIPTION
Without this we get such failures when running QA:

```#14 [builder 3/4] WORKDIR /mnt
#15 [builder 4/4] RUN --mount=type=bind,from=code,target=/mnt cargo build --release --target-dir /tmp
#15 0.273     Updating crates.io index
#15 2.883 error: failed to write /mnt/Cargo.lock
#15 2.883 
#15 2.883 Caused by:
#15 2.883   failed to open: /mnt/Cargo.lock
#15 2.883 
#15 2.883 Caused by:
#15 2.883   Read-only file system (os error 30)
```

https://github.com/informalsystems/malachite/actions/runs/16723245984/job/47332329264