### PR TITLE
fix(tests): remove tempfile deprecated method

### DIFF
--- a/code/crates/starknet/test/src/lib.rs
+++ b/code/crates/starknet/test/src/lib.rs
@@ -49,7 +49,8 @@ pub struct TestRunner {
 fn temp_dir(id: NodeId) -> PathBuf {
     TempDir::with_prefix(format!("malachitebft-test-app-{id}-"))
         .unwrap()
-        .into_path()
+        .keep()
+        .to_path_buf()
 }
 
 #[async_trait]

--- a/code/crates/test/tests/it/main.rs
+++ b/code/crates/test/tests/it/main.rs
@@ -56,7 +56,8 @@ pub struct TestRunner {
 fn temp_dir(id: NodeId) -> PathBuf {
     TempDir::with_prefix(format!("malachitebft-test-app-{id}"))
         .unwrap()
-        .into_path()
+        .keep()
+        .to_path_buf()
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Currently, what is under the `main` branch cannot compile due to:
```
error: use of deprecated method `tempfile::TempDir::into_path`: use TempDir::keep()
Error:   --> crates/starknet/test/src/lib.rs:52:10
   |
52 |         .into_path()
   |          ^^^^^^^^^
   |
   = note: `-D deprecated` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(deprecated)]
```
that stems from [here](https://github.com/informalsystems/malachite/commit/461dfddaf78fa3d6df17f41eec96cd093f3059e3).
In this newer version of `tempfile`, [`into_path`](https://docs.rs/tempfile/3.21.0/tempfile/struct.TempDir.html#method.into_path) has been deprecated.


---

### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
