### PR TITLE
fix(code/engine,sync): introduce new sync queue and eliminate sync_height

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -2563,6 +2563,7 @@ dependencies = [
  "informalsystems-malachitebft-peer",
  "libp2p",
  "rand 0.8.5",
+ "rstest",
  "serde",
  "thiserror 2.0.16",
  "tracing",
@@ -4450,6 +4451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4481,6 +4488,35 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -2604,6 +2604,7 @@ dependencies = [
  "sha3",
  "signature",
  "tempfile",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
 ]

--- a/code/crates/core-consensus/src/handle/sync.rs
+++ b/code/crates/core-consensus/src/handle/sync.rs
@@ -27,7 +27,7 @@ where
     if consensus_height < cert_height {
         debug!(%consensus_height, %cert_height, "Received value response for higher height, queuing for later");
 
-        state.buffer_input(cert_height, Input::SyncValueResponse(value), metrics);
+        state.buffer_sync_input(cert_height, Input::SyncValueResponse(value), metrics);
 
         return Ok(());
     }

--- a/code/crates/core-consensus/src/state.rs
+++ b/code/crates/core-consensus/src/state.rs
@@ -27,6 +27,9 @@ where
     /// A queue of inputs that were received before the driver started.
     pub input_queue: BoundedQueue<Ctx::Height, Input<Ctx>>,
 
+    /// A queue specifically for `SyncValueResponse`s inputs that were received at a higher height.
+    pub sync_input_queue: BoundedQueue<Ctx::Height, Input<Ctx>>,
+
     /// The proposals to decide on.
     pub full_proposal_keeper: FullProposalKeeper<Ctx>,
 
@@ -55,6 +58,7 @@ where
             driver,
             params,
             input_queue: BoundedQueue::new(queue_capacity),
+            sync_input_queue: BoundedQueue::new(queue_capacity),
             full_proposal_keeper: Default::default(),
             last_signed_prevote: None,
             last_signed_precommit: None,
@@ -195,13 +199,38 @@ where
         }
     }
 
+    /// Queue a sync input for later processing, only keep inputs for the highest height seen so far.
+    pub fn buffer_sync_input(
+        &mut self,
+        height: Ctx::Height,
+        input: Input<Ctx>,
+        _metrics: &Metrics,
+    ) {
+        self.sync_input_queue.push(height, input);
+
+        #[cfg(feature = "metrics")]
+        {
+            _metrics
+                .sync_queue_heights
+                .set(self.sync_input_queue.len() as i64);
+            _metrics
+                .sync_queue_size
+                .set(self.sync_input_queue.size() as i64);
+        }
+    }
+
     /// Take all inputs that are pending for the specified height and remove from the input queue.
     pub fn take_pending_inputs(&mut self, _metrics: &Metrics) -> Vec<Input<Ctx>>
     where
         Ctx: Context,
     {
-        let inputs = self
+        let mut inputs = self
             .input_queue
+            .shift_and_take(&self.height())
+            .collect::<Vec<_>>();
+
+        let mut sync_response_inputs = self
+            .sync_input_queue
             .shift_and_take(&self.height())
             .collect::<Vec<_>>();
 
@@ -211,6 +240,7 @@ where
             _metrics.queue_size.set(self.input_queue.size() as i64);
         }
 
+        inputs.append(&mut sync_response_inputs);
         inputs
     }
 

--- a/code/crates/core-consensus/src/state.rs
+++ b/code/crates/core-consensus/src/state.rs
@@ -238,10 +238,18 @@ where
         {
             _metrics.queue_heights.set(self.input_queue.len() as i64);
             _metrics.queue_size.set(self.input_queue.size() as i64);
+            _metrics
+                .sync_queue_heights
+                .set(self.sync_input_queue.len() as i64);
+            _metrics
+                .sync_queue_size
+                .set(self.sync_input_queue.size() as i64);
         }
 
-        inputs.append(&mut sync_response_inputs);
-        inputs
+        // We first return the sync-related inputs because if we can successfully apply them, we will move
+        // to the next height, and therefore we can skip applying pending inputs for the just-committed height.
+        sync_response_inputs.append(&mut inputs);
+        sync_response_inputs
     }
 
     pub fn print_state(&self) {

--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -21,7 +21,9 @@ use malachitebft_core_types::{
     ValidatorSet, Validity, Value, ValueId, ValueOrigin, ValueResponse as CoreValueResponse, Vote,
 };
 use malachitebft_metrics::Metrics;
-use malachitebft_sync::{self as sync, HeightStartType, OutboundRequestId, Response, ValueResponse};
+use malachitebft_sync::{
+    self as sync, HeightStartType, OutboundRequestId, Response, ValueResponse,
+};
 
 use crate::host::{HostMsg, HostRef, LocallyProposedValue, Next, ProposedValue};
 use crate::network::{NetworkEvent, NetworkMsg, NetworkRef};
@@ -158,7 +160,10 @@ impl<Ctx: Context> fmt::Display for Msg<Ctx> {
             ),
             Msg::RestartHeight(height, _) => write!(f, "RestartHeight(height={height})"),
             Msg::DumpState(_) => write!(f, "DumpState"),
-            Msg::ProcessSyncResponse(request_id, peer_id, _) => write!(f, "ProcessSyncResponse(request_id={request_id}, peer_id={peer_id})"),
+            Msg::ProcessSyncResponse(request_id, peer_id, _) => write!(
+                f,
+                "ProcessSyncResponse(request_id={request_id}, peer_id={peer_id})"
+            ),
         }
     }
 }
@@ -616,10 +621,14 @@ where
                 Ok(())
             }
 
-            Msg::ProcessSyncResponse(request_id, peer_id, sync::Response::ValueResponse(ValueResponse {
+            Msg::ProcessSyncResponse(
+                request_id,
+                peer_id,
+                sync::Response::ValueResponse(ValueResponse {
                     start_height,
                     values,
-                })) => {
+                }),
+            ) => {
                 debug!(%start_height, %request_id, "Received sync response for processing with {} values", values.len());
 
                 if values.is_empty() {
@@ -1350,8 +1359,8 @@ where
         if let Some(sync) = self.sync.clone() {
             ractor::call!(sync, |reply_to| {
                 SyncMsg::SetConsensusActor(myself.clone(), reply_to)
-            }).map_err(|e|
-                eyre!("Failed to set consensus actor: {e:?}"))?;
+            })
+            .map_err(|e| eyre!("Failed to set consensus actor: {e:?}"))?;
         }
 
         Ok(State {

--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -401,15 +401,6 @@ where
                     state.set_phase(Phase::Recovering);
                 }
 
-                // Notify the sync actor that we have started a new height
-                if let Some(sync) = &self.sync {
-                    let start_type = HeightStartType::from_is_restart(is_restart);
-
-                    if let Err(e) = sync.cast(SyncMsg::StartedHeight(height, start_type)) {
-                        error!(%height, "Error when notifying sync of started height: {e}")
-                    }
-                }
-
                 // Start consensus for the given height
                 let result = self
                     .process_input(
@@ -421,6 +412,15 @@ where
 
                 if let Err(e) = result {
                     error!(%height, "Error when starting height: {e}");
+                }
+
+                // Notify the sync actor that we have started a new height
+                if let Some(sync) = &self.sync {
+                    let start_type = HeightStartType::from_is_restart(is_restart);
+
+                    if let Err(e) = sync.cast(SyncMsg::StartedHeight(height, start_type)) {
+                        error!(%height, "Error when notifying sync of started height: {e}")
+                    }
                 }
 
                 if !wal_entries.is_empty() {

--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -643,15 +643,7 @@ where
                         .process_sync_response(&myself, state, peer_id, height, value)
                         .await
                     {
-                        // At this point, `process_sync_response` has already sent a message
-                        // about an invalid value, etc. to the sync actor. The sync actor
-                        // will then re-request this range again from some peer.
-                        // Because of this, in case of failing to process the response, we need
-                        // to exit early this loop to avoid issuing multiple parallel requests
-                        // for the same range of values. There's also no benefit in processing
-                        // the rest of the values.
                         error!(%start_height, %height, %request_id, "Failed to process sync response:{e:?}");
-                        break;
                     }
 
                     height = height.increment();

--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -21,7 +21,7 @@ use malachitebft_core_types::{
     ValidatorSet, Validity, Value, ValueId, ValueOrigin, ValueResponse as CoreValueResponse, Vote,
 };
 use malachitebft_metrics::Metrics;
-use malachitebft_sync::{self as sync, HeightStartType, ValueResponse};
+use malachitebft_sync::{self as sync, HeightStartType, OutboundRequestId, Response, ValueResponse};
 
 use crate::host::{HostMsg, HostRef, LocallyProposedValue, Next, ProposedValue};
 use crate::network::{NetworkEvent, NetworkMsg, NetworkRef};
@@ -118,6 +118,9 @@ pub enum Msg<Ctx: Context> {
 
     /// Request to dump the current consensus state
     DumpState(RpcReplyPort<StateDump<Ctx>>),
+
+    /// Process (i.e., verify commit certificate) the values of a sync response.
+    ProcessSyncResponse(OutboundRequestId, PeerId, Response<Ctx>),
 }
 
 impl<Ctx: Context> fmt::Display for Msg<Ctx> {
@@ -155,6 +158,7 @@ impl<Ctx: Context> fmt::Display for Msg<Ctx> {
             ),
             Msg::RestartHeight(height, _) => write!(f, "RestartHeight(height={height})"),
             Msg::DumpState(_) => write!(f, "DumpState"),
+            Msg::ProcessSyncResponse(request_id, peer_id, _) => write!(f, "ProcessSyncResponse(request_id={request_id}, peer_id={peer_id})"),
         }
     }
 }
@@ -488,43 +492,6 @@ where
                         }
                     }
 
-                    NetworkEvent::SyncResponse(
-                        request_id,
-                        peer,
-                        Some(sync::Response::ValueResponse(ValueResponse {
-                            start_height,
-                            values,
-                        })),
-                    ) => {
-                        debug!(%start_height, %request_id, "Received sync response with {} values", values.len());
-
-                        if values.is_empty() {
-                            error!(%start_height, %request_id, "Received empty value sync response");
-                            return Ok(());
-                        };
-
-                        // Process values sequentially starting from the lowest height
-                        let mut height = start_height;
-                        for value in values.iter() {
-                            if let Err(e) = self
-                                .process_sync_response(&myself, state, peer, height, value)
-                                .await
-                            {
-                                // At this point, `process_sync_response` has already sent a message
-                                // about an invalid value, etc. to the sync actor. The sync actor
-                                // will then, re-request this range again from some peer.
-                                // Because of this, in case of failing to process the response, we need
-                                // to exit early this loop to avoid issuing multiple parallel requests
-                                // for the same range of values. There's also no benefit in processing
-                                // the rest of the values.
-                                error!(%start_height, %height, %request_id, "Failed to process sync response:{e:?}");
-                                break;
-                            }
-
-                            height = height.increment();
-                        }
-                    }
-
                     NetworkEvent::Vote(from, vote) => {
                         if let Err(e) = self
                             .process_input(&myself, state, ConsensusInput::Vote(vote))
@@ -644,6 +611,41 @@ where
 
                 if let Err(e) = reply_to.send(dump) {
                     error!("Failed to reply with state dump: {e}");
+                }
+
+                Ok(())
+            }
+
+            Msg::ProcessSyncResponse(request_id, peer_id, sync::Response::ValueResponse(ValueResponse {
+                    start_height,
+                    values,
+                })) => {
+                debug!(%start_height, %request_id, "Received sync response for processing with {} values", values.len());
+
+                if values.is_empty() {
+                    error!(%start_height, %request_id, "Received empty value sync response");
+                    return Ok(());
+                };
+
+                // Process values sequentially starting from the lowest height
+                let mut height = start_height;
+                for value in values.iter() {
+                    if let Err(e) = self
+                        .process_sync_response(&myself, state, peer_id, height, value)
+                        .await
+                    {
+                        // At this point, `process_sync_response` has already sent a message
+                        // about an invalid value, etc. to the sync actor. The sync actor
+                        // will then re-request this range again from some peer.
+                        // Because of this, in case of failing to process the response, we need
+                        // to exit early this loop to avoid issuing multiple parallel requests
+                        // for the same range of values. There's also no benefit in processing
+                        // the rest of the values.
+                        error!(%start_height, %height, %request_id, "Failed to process sync response:{e:?}");
+                        break;
+                    }
+
+                    height = height.increment();
                 }
 
                 Ok(())
@@ -1342,6 +1344,15 @@ where
 
         self.network
             .cast(NetworkMsg::Subscribe(Box::new(myself.clone())))?;
+
+        // Now that the consensus actor is about to start, we inform the sync actor about it
+        // so that the sync actor can send messages to the consensus actor.
+        if let Some(sync) = self.sync.clone() {
+            ractor::call!(sync, |reply_to| {
+                SyncMsg::SetConsensusActor(myself.clone(), reply_to)
+            }).map_err(|e|
+                eyre!("Failed to set consensus actor: {e:?}"))?;
+        }
 
         Ok(State {
             timers: Timers::new(Box::new(myself)),

--- a/code/crates/engine/src/sync.rs
+++ b/code/crates/engine/src/sync.rs
@@ -264,19 +264,16 @@ where
                 value_response,
                 r,
             ) => {
-                match consensus_actor {
-                    Some(consensus) => {
-                        consensus.cast(ConsensusMsg::ProcessSyncResponse(
-                            request_id,
-                            peer_id,
-                            ValueResponse(value_response),
-                        ))?;
-                    }
-                    None => {
-                        // This should NEVER happen because we only send requests to peers and hence
-                        // receive responses if the consensus actor is set.
-                        error!(%request_id, %peer_id, "Received sync response before consensus actor was set.");
-                    }
+                if let Some(consensus) = consensus_actor {
+                    consensus.cast(ConsensusMsg::ProcessSyncResponse(
+                        request_id,
+                        peer_id,
+                        ValueResponse(value_response),
+                    ))?;
+                } else {
+                    // This should NEVER happen because we only send requests to peers and hence
+                    // receive responses if the consensus actor is set.
+                    error!(%request_id, %peer_id, "Received sync response before consensus actor was set.");
                 }
 
                 Ok(r.resume_with(()))

--- a/code/crates/engine/src/sync.rs
+++ b/code/crates/engine/src/sync.rs
@@ -561,7 +561,6 @@ where
         skip_all,
         fields(
             height.tip = %state.sync.tip_height,
-            height.sync = %state.sync.sync_height,
         ),
     )]
     async fn handle(

--- a/code/crates/engine/src/sync.rs
+++ b/code/crates/engine/src/sync.rs
@@ -12,6 +12,7 @@ use rand::SeedableRng;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn, Instrument};
 
+use crate::consensus::{ConsensusMsg, ConsensusRef};
 use crate::host::{HostMsg, HostRef};
 use crate::network::{NetworkEvent, NetworkMsg, NetworkRef, Status};
 use crate::util::ticker::ticker;
@@ -24,7 +25,6 @@ use malachitebft_sync::{
     self as sync, HeightStartType, InboundRequestId, OutboundRequestId, RawDecidedValue, Request,
     Response, Resumable,
 };
-use crate::consensus::{ConsensusMsg, ConsensusRef};
 
 /// Codec for sync protocol messages
 ///
@@ -248,11 +248,20 @@ where
                 Ok(r.resume_with(()))
             }
 
-            Effect::NotifyConsensusToProcessSyncResponse(request_id, peer_id, value_response, r) => {
+            Effect::NotifyConsensusToProcessSyncResponse(
+                request_id,
+                peer_id,
+                value_response,
+                r,
+            ) => {
                 let consensus_actor = consensus_actor.as_ref().unwrap();
-                consensus_actor.cast(ConsensusMsg::ProcessSyncResponse(request_id, peer_id, ValueResponse(value_response)))?;
+                consensus_actor.cast(ConsensusMsg::ProcessSyncResponse(
+                    request_id,
+                    peer_id,
+                    ValueResponse(value_response),
+                ))?;
 
-               Ok(r.resume_with(()))
+                Ok(r.resume_with(()))
             }
 
             Effect::SendValueRequest(peer_id, value_request, r) => {

--- a/code/crates/metrics/src/metrics.rs
+++ b/code/crates/metrics/src/metrics.rs
@@ -87,8 +87,14 @@ pub struct Inner {
     /// Number of heights in the consensus input queue
     pub queue_heights: Gauge,
 
+    /// Number of heights in the consensus sync input queue
+    pub sync_queue_heights: Gauge,
+
     /// Number of inputs in the consensus input queue across all heights
     pub queue_size: Gauge,
+
+    /// Number of sync inputs in the consensus input queue across all heights
+    pub sync_queue_size: Gauge,
 
     /// Internal state for measuring time taken for consensus
     instant_consensus_started: Arc<AtomicInstant>,
@@ -117,7 +123,9 @@ impl Metrics {
             signature_signing_time: Histogram::new(exponential_buckets(0.001, 2.0, 10)),
             signature_verification_time: Histogram::new(exponential_buckets(0.001, 2.0, 10)),
             queue_heights: Gauge::default(),
+            sync_queue_heights: Gauge::default(),
             queue_size: Gauge::default(),
+            sync_queue_size: Gauge::default(),
             instant_consensus_started: Arc::new(AtomicInstant::empty()),
             instant_block_started: Arc::new(AtomicInstant::empty()),
             instant_step_started: Arc::new(Mutex::new((Step::Unstarted, Instant::now()))),

--- a/code/crates/metrics/src/metrics.rs
+++ b/code/crates/metrics/src/metrics.rs
@@ -213,6 +213,18 @@ impl Metrics {
                 "Number of inputs in the consensus input queue across all heights",
                 metrics.queue_size.clone(),
             );
+
+            registry.register(
+                "sync queue_heights",
+                "Number of heights in the sync input queue",
+                metrics.sync_queue_heights.clone(),
+            );
+
+            registry.register(
+                "sync queue_size",
+                "Number of inputs in the consensus sync input queue across all heights",
+                metrics.sync_queue_size.clone(),
+            );
         });
 
         metrics

--- a/code/crates/sync/Cargo.toml
+++ b/code/crates/sync/Cargo.toml
@@ -37,6 +37,7 @@ tracing = { workspace = true }
 malachitebft-peer = { workspace = true, features = ["rand"] }
 arbtest = { workspace = true }
 tracing-subscriber = { workspace = true }
+rstest = "0.26.1"
 
 [lints]
 workspace = true

--- a/code/crates/sync/src/effect.rs
+++ b/code/crates/sync/src/effect.rs
@@ -42,6 +42,9 @@ pub trait Resumable<Ctx: Context> {
 #[derive_where(Debug)]
 #[derive(Error)]
 pub enum Error<Ctx: Context> {
+    #[error("Failed to find a peer to re-request values from")]
+    PeerNotFound(),
+
     /// The coroutine was resumed with a value which
     /// does not match the expected type of resume value.
     #[error("Unexpected resume: {0:?}, expected one of: {1}")]

--- a/code/crates/sync/src/effect.rs
+++ b/code/crates/sync/src/effect.rs
@@ -78,13 +78,13 @@ pub enum Effect<Ctx: Context> {
         resume::Continue,
     ),
 
-
     /// Notify consensus to process a sync response.
     NotifyConsensusToProcessSyncResponse(
         OutboundRequestId,
         PeerId,
         ValueResponse<Ctx>,
-        resume::Continue),
+        resume::Continue,
+    ),
 }
 
 pub mod resume {

--- a/code/crates/sync/src/effect.rs
+++ b/code/crates/sync/src/effect.rs
@@ -77,6 +77,14 @@ pub enum Effect<Ctx: Context> {
         RangeInclusive<Ctx::Height>,
         resume::Continue,
     ),
+
+
+    /// Notify consensus to process a sync response.
+    NotifyConsensusToProcessSyncResponse(
+        OutboundRequestId,
+        PeerId,
+        ValueResponse<Ctx>,
+        resume::Continue),
 }
 
 pub mod resume {

--- a/code/crates/sync/src/effect.rs
+++ b/code/crates/sync/src/effect.rs
@@ -42,9 +42,6 @@ pub trait Resumable<Ctx: Context> {
 #[derive_where(Debug)]
 #[derive(Error)]
 pub enum Error<Ctx: Context> {
-    #[error("Failed to find a peer to re-request values from")]
-    PeerNotFound(),
-
     /// The coroutine was resumed with a value which
     /// does not match the expected type of resume value.
     #[error("Unexpected resume: {0:?}, expected one of: {1}")]

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -479,8 +479,9 @@ where
                 %request_id, peer.actual = %peer_id, peer.expected = %stored_peer_id,
                 "Received response from different peer than expected"
             );
+        } else {
+            re_request_values_from_peer_except(co, state, metrics, request_id, Some(peer_id)).await?;
         }
-        re_request_values_from_peer_except(co, state, metrics, request_id, Some(peer_id)).await?;
     } else {
         error!(%peer_id, %height, "Received height of invalid value for unknown request");
     }

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -65,9 +65,7 @@ where
 
         Input::Status(status) => on_status(co, state, metrics, status).await,
 
-        Input::StartedHeight(height, restart) => {
-            on_started_height(co, state, metrics, height, restart).await
-        }
+        Input::StartedHeight(height, restart) => on_started_height(state, height, restart).await,
 
         Input::Decided(height) => on_decided(state, metrics, height).await,
 
@@ -297,9 +295,7 @@ where
 }
 
 pub async fn on_started_height<Ctx>(
-    co: Co<Ctx>,
     state: &mut State<Ctx>,
-    metrics: &Metrics,
     height: Ctx::Height,
     start_type: HeightStartType,
 ) -> Result<(), Error<Ctx>>
@@ -316,10 +312,6 @@ where
 
     // The tip is the last decided value.
     state.tip_height = height.decrement().unwrap_or_default();
-
-    // Trigger potential requests if possible. Consensus just started for height `height` and
-    // hence it makes sense to request this height in case some peer already has it.
-    request_values(co, state, height, metrics).await?;
 
     Ok(())
 }

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -99,6 +99,7 @@ where
                     && end.as_u64() <= requested_range.end().as_u64()
                     && response.values.len() as u64 == range_len;
                 if is_valid {
+                    perform!(co, Effect::NotifyConsensusToProcessSyncResponse(request_id.clone(), peer_id, response.clone(), Default::default()));
                     return on_value_response(co, state, metrics, request_id, peer_id, response)
                         .await;
                 } else {

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -90,8 +90,7 @@ where
                         %request_id, peer.actual = %peer_id, peer.expected = %stored_peer_id,
                         "Received response from different peer than expected"
                     );
-                    return on_invalid_value_response(co, state, metrics, request_id, peer_id)
-                        .await;
+                    return Ok(());
                 }
 
                 let is_valid = start.as_u64() == requested_range.start().as_u64()
@@ -321,7 +320,7 @@ where
                 %request_id, peer.actual = %peer_id, peer.expected = %stored_peer_id,
                 "Received response from different peer than expected"
             );
-            return on_invalid_value_response(co, state, metrics, request_id, peer_id).await;
+            return Ok(());
         }
 
         let range_len = requested_range.end().as_u64() - requested_range.start().as_u64() + 1;

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -144,9 +144,7 @@ where
             );
 
             // Update peer's response time.
-            let start = response.start_height;
             debug!(start = %start, num_values = %response.values.len(), %peer_id, "Received response from peer");
-
             if let Some(response_time) = metrics.value_response_received(start.as_u64()) {
                 state.peer_scorer.update_score_with_metrics(
                     peer_id,
@@ -172,6 +170,8 @@ where
                     match take_inflight_if_peer_matches(state, &request_id, peer_id) {
                         Ok(r) => r,
                         Err(e) => {
+                            // This should NEVER happen because we should only be able to receive
+                            // a time out from a request that we send.
                             error!("Failed taking inflight request: {e}");
                             return Ok(());
                         }

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -436,7 +436,7 @@ where
 /// Excise `height` from the first (and only) range in `ranges` that contains it and then append up to two ranges
 /// that exclude `height`. We assume that `ranges` does not contain a height more than once.
 /// Return `Err` if no range contains `height` or if `height - 1` underflows.
-fn excise_height<H>(ranges: &mut Vec<RangeInclusive<H>>, height: H) -> Result<(), String>
+pub fn excise_height<H>(ranges: &mut Vec<RangeInclusive<H>>, height: H) -> Result<(), String>
 where
     H: Height,
 {

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -480,7 +480,8 @@ where
                 "Received response from different peer than expected"
             );
         } else {
-            re_request_values_from_peer_except(co, state, metrics, request_id, Some(peer_id)).await?;
+            re_request_values_from_peer_except(co, state, metrics, request_id, Some(peer_id))
+                .await?;
         }
     } else {
         error!(%peer_id, %height, "Received height of invalid value for unknown request");

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -99,7 +99,15 @@ where
                     && end.as_u64() <= requested_range.end().as_u64()
                     && response.values.len() as u64 == range_len;
                 if is_valid {
-                    perform!(co, Effect::NotifyConsensusToProcessSyncResponse(request_id.clone(), peer_id, response.clone(), Default::default()));
+                    perform!(
+                        co,
+                        Effect::NotifyConsensusToProcessSyncResponse(
+                            request_id.clone(),
+                            peer_id,
+                            response.clone(),
+                            Default::default()
+                        )
+                    );
                     return on_value_response(co, state, metrics, request_id, peer_id, response)
                         .await;
                 } else {

--- a/code/crates/sync/src/state.rs
+++ b/code/crates/sync/src/state.rs
@@ -4,9 +4,9 @@ use std::cmp::max;
 use std::collections::{BTreeMap, HashMap};
 use std::ops::RangeInclusive;
 
+use crate::handle::excise_height;
 use crate::scoring::{ema, PeerScorer, Strategy};
 use crate::{Config, OutboundRequestId, Status};
-use crate::handle::excise_height;
 
 pub struct State<Ctx>
 where

--- a/code/crates/sync/src/state.rs
+++ b/code/crates/sync/src/state.rs
@@ -173,11 +173,10 @@ where
         start..=*range.end()
     }
 
-    /// When the tip height is higher than the requested range, then the request
-    /// has been fully validated and it can be removed.
-    pub fn remove_fully_validated_requests(&mut self) {
+    /// Prunes the ranges of pending-consensus requests which end is <= `up_to_height`
+    pub fn prune_pending_consensus_requests(&mut self, up_to_height: &Ctx::Height) {
         self.pending_consensus_requests.retain(|_, (ranges, _)| {
-            ranges.retain(|range| range.end() > &self.tip_height);
+            ranges.retain(|range| range.end() > up_to_height);
             !ranges.is_empty()
         });
     }

--- a/code/crates/sync/src/state.rs
+++ b/code/crates/sync/src/state.rs
@@ -1,12 +1,76 @@
-use std::cmp::max;
-use std::collections::{BTreeMap, HashMap};
-use std::ops::RangeInclusive;
-
 use malachitebft_core_types::{Context, Height};
 use malachitebft_peer::PeerId;
+use std::cmp::{max, Ordering};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::ops::RangeInclusive;
 
 use crate::scoring::{ema, PeerScorer, Strategy};
 use crate::{Config, OutboundRequestId, Status};
+
+#[derive(Clone)]
+pub struct QueuedRequest<Ctx>
+where
+    Ctx: Context,
+{
+    pub range: RangeInclusive<Ctx::Height>,
+    pub peer_id: PeerId,
+}
+
+impl<Ctx> QueuedRequest<Ctx>
+where
+    Ctx: Context,
+{
+    // FIXME
+    pub(crate) fn new(range: RangeInclusive<Ctx::Height>, peer_id: PeerId) -> QueuedRequest<Ctx>
+    where
+        Ctx: Context,
+    {
+        QueuedRequest { range, peer_id }
+    }
+}
+
+// Make Eq/PartialEq consistent with Ord:
+impl<Ctx: Context> PartialEq for QueuedRequest<Ctx>
+where
+    Ctx::Height: PartialEq,
+    PeerId: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.range.start() == other.range.start()
+            && self.range.end() == other.range.end()
+            && self.peer_id == other.peer_id
+    }
+}
+impl<Ctx: Context> Eq for QueuedRequest<Ctx>
+where
+    Ctx::Height: Eq,
+    PeerId: Eq,
+{
+}
+
+// Total order for BTreeSet:
+impl<Ctx: Context> Ord for QueuedRequest<Ctx>
+where
+    Ctx::Height: Ord,
+    PeerId: Ord,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.range
+            .start()
+            .cmp(other.range.start())
+            .then(self.range.end().cmp(other.range.end()))
+            .then(self.peer_id.cmp(&other.peer_id))
+    }
+}
+impl<Ctx: Context> PartialOrd for QueuedRequest<Ctx>
+where
+    Ctx::Height: Ord,
+    PeerId: Ord,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
 
 pub struct State<Ctx>
 where
@@ -26,6 +90,9 @@ where
     /// Next height to send a sync request.
     /// Invariant: `sync_height > tip_height`
     pub sync_height: Ctx::Height,
+
+    /// Requests that are still inflight (i.e., we have not received a response yet).
+    pub queued_requests: BTreeSet<QueuedRequest<Ctx>>,
 
     /// Requests that are still inflight (i.e., we have not received a response yet).
     pub inflight_requests: BTreeMap<OutboundRequestId, (RangeInclusive<Ctx::Height>, PeerId)>,
@@ -61,6 +128,7 @@ where
             started: false,
             tip_height: Ctx::Height::ZERO,
             sync_height: Ctx::Height::ZERO,
+            queued_requests: BTreeSet::new(),
             inflight_requests: BTreeMap::new(),
             pending_consensus_requests: BTreeMap::new(),
             peers: BTreeMap::new(),
@@ -157,11 +225,16 @@ where
     /// Get the request that contains the given height.
     ///
     /// Assumes a height cannot be in multiple pending requests.
-    pub fn get_request_id_by(&self, height: Ctx::Height) -> Option<(OutboundRequestId, PeerId)> {
+    pub fn get_request_id_by(
+        &self,
+        height: Ctx::Height,
+    ) -> Option<(OutboundRequestId, PeerId, RangeInclusive<Ctx::Height>)> {
         self.pending_consensus_requests
             .iter()
             .find(|(_, (range, _))| range.contains(&height))
-            .map(|(request_id, (_, stored_peer_id))| (request_id.clone(), *stored_peer_id))
+            .map(|(request_id, (range, stored_peer_id))| {
+                (request_id.clone(), *stored_peer_id, range.clone())
+            })
     }
 
     /// Return a new range of heights, trimming from the beginning any height

--- a/code/crates/sync/src/state.rs
+++ b/code/crates/sync/src/state.rs
@@ -150,18 +150,22 @@ where
     ///
     /// Assumes a height cannot be in multiple pending requests.
     pub fn get_pending_consensus_request_id_by(
-        &self,
+        &mut self,
         height: Ctx::Height,
-    ) -> Option<(OutboundRequestId, PeerId, Vec<RangeInclusive<Ctx::Height>>)> {
-        self.pending_consensus_requests
-            .iter()
-            .find_map(|(request_id, (ranges, stored_peer_id))| {
+    ) -> Option<(
+        OutboundRequestId,
+        PeerId,
+        &mut Vec<RangeInclusive<Ctx::Height>>,
+    )> {
+        self.pending_consensus_requests.iter_mut().find_map(
+            |(request_id, (ranges, stored_peer_id))| {
                 if ranges.iter().any(|range| range.contains(&height)) {
-                    Some((request_id.clone(), *stored_peer_id, ranges.clone()))
+                    Some((request_id.clone(), *stored_peer_id, ranges))
                 } else {
                     None
                 }
-            })
+            },
+        )
     }
 
     /// Return a new range of heights, trimming from the beginning any height

--- a/code/crates/sync/src/state.rs
+++ b/code/crates/sync/src/state.rs
@@ -25,9 +25,16 @@ where
     /// Requests that are still inflight (i.e., we have not received a response yet).
     pub inflight_requests: BTreeMap<OutboundRequestId, (RangeInclusive<Ctx::Height>, PeerId)>,
 
-    /// The requested range of heights that we have received and are waiting for consensus verification.
+    /// The requested heights that we have received and are waiting for consensus verification.
+    /// Note that even though a peer requests a range of values as a whole, the consensus verifies each
+    /// value on its own. As a result, the consensus informs the sync actor per value (e.g., see
+    /// `InvalidValue` and `ValueProcessingError` messages).
+    /// For example, we can have a scenario where a request `r` for [10..20] gets an invalid value
+    /// for height 15. In such a scenario, `r` might still be waiting for consensus verification
+    /// for heights [10..14] and [16..20].
+    /// To tackle the above, we store a vec of ranges instead of a single range of heights.
     pub pending_consensus_requests:
-        BTreeMap<OutboundRequestId, (RangeInclusive<Ctx::Height>, PeerId)>,
+        BTreeMap<OutboundRequestId, (Vec<RangeInclusive<Ctx::Height>>, PeerId)>,
 
     /// The set of peers we are connected to in order to get values, certificates and votes.
     pub peers: BTreeMap<PeerId, Status<Ctx>>,
@@ -70,16 +77,6 @@ where
 
     pub fn update_status(&mut self, status: Status<Ctx>) {
         self.peers.insert(status.peer_id, status);
-    }
-
-    pub fn update_request(
-        &mut self,
-        request_id: OutboundRequestId,
-        peer_id: PeerId,
-        range: RangeInclusive<Ctx::Height>,
-    ) {
-        self.pending_consensus_requests
-            .insert(request_id, (range, peer_id));
     }
 
     /// Filter peers to only include those that can provide the given range of values, or at least a prefix of the range.
@@ -154,11 +151,16 @@ where
     pub fn get_pending_consensus_request_id_by(
         &self,
         height: Ctx::Height,
-    ) -> Option<(OutboundRequestId, PeerId)> {
+    ) -> Option<(OutboundRequestId, PeerId, Vec<RangeInclusive<Ctx::Height>>)> {
         self.pending_consensus_requests
             .iter()
-            .find(|(_, (range, _))| range.contains(&height))
-            .map(|(request_id, (_, stored_peer_id))| (request_id.clone(), *stored_peer_id))
+            .find_map(|(request_id, (ranges, stored_peer_id))| {
+                if ranges.iter().any(|range| range.contains(&height)) {
+                    Some((request_id.clone(), *stored_peer_id, ranges.clone()))
+                } else {
+                    None
+                }
+            })
     }
 
     /// Return a new range of heights, trimming from the beginning any height
@@ -174,7 +176,9 @@ where
     /// When the tip height is higher than the requested range, then the request
     /// has been fully validated and it can be removed.
     pub fn remove_fully_validated_requests(&mut self) {
-        self.pending_consensus_requests
-            .retain(|_, (range, _)| range.end() > &self.tip_height);
+        self.pending_consensus_requests.retain(|_, (ranges, _)| {
+            ranges.retain(|range| range.end() > &self.tip_height);
+            !ranges.is_empty()
+        });
     }
 }

--- a/code/crates/test/Cargo.toml
+++ b/code/crates/test/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = { workspace = true }
 sha3 = { workspace = true }
 signature = { workspace = true }
 tokio = { workspace = true }
+thiserror = "2.0.16"
 
 [dev-dependencies]
 malachitebft-test-app.workspace = true

--- a/code/crates/test/app/src/state.rs
+++ b/code/crates/test/app/src/state.rs
@@ -23,8 +23,9 @@ use malachitebft_test::{
 };
 
 use crate::config::Config;
-use crate::store::{DecidedValue, Store};
+use crate::store::Store;
 use crate::streaming::{PartStreamsMap, ProposalParts};
+use malachitebft_test::decided_value::DecidedValue;
 
 /// Number of historical values to keep in the store
 const HISTORY_LENGTH: u64 = 500;
@@ -269,7 +270,14 @@ impl State {
 
     /// Retrieves a decided block at the given height
     pub async fn get_decided_value(&self, height: Height) -> Option<DecidedValue> {
-        self.store.get_decided_value(height).await.ok().flatten()
+        let value = self.store.get_decided_value(height).await.ok().flatten();
+
+        // if middleware contains a value, return the middleware's value
+        if let Some(dv) = self.ctx.middleware().get_decided_value(height) {
+            return Some(dv);
+        }
+
+        value
     }
 
     /// Commits a value with the given certificate, updating internal state

--- a/code/crates/test/app/src/store.rs
+++ b/code/crates/test/app/src/store.rs
@@ -21,12 +21,7 @@ use keys::{HeightKey, UndecidedValueKey};
 
 use crate::store::keys::PendingValueKey;
 use crate::streaming::ProposalParts;
-
-#[derive(Clone, Debug)]
-pub struct DecidedValue {
-    pub value: Value,
-    pub certificate: CommitCertificate<TestContext>,
-}
+use malachitebft_test::decided_value::DecidedValue;
 
 fn decode_certificate(bytes: &[u8]) -> Result<CommitCertificate<TestContext>, ProtoError> {
     let proto = proto::CommitCertificate::decode(bytes)?;

--- a/code/crates/test/src/decided_value.rs
+++ b/code/crates/test/src/decided_value.rs
@@ -1,0 +1,8 @@
+use crate::{TestContext, Value};
+use malachitebft_core_types::CommitCertificate;
+
+#[derive(Clone, Debug)]
+pub struct DecidedValue {
+    pub value: Value,
+    pub certificate: CommitCertificate<TestContext>,
+}

--- a/code/crates/test/src/lib.rs
+++ b/code/crates/test/src/lib.rs
@@ -14,6 +14,7 @@ mod value;
 mod vote;
 
 pub mod codec;
+pub mod decided_value;
 pub mod middleware;
 pub mod proposer_selector;
 pub mod proto;

--- a/code/crates/test/src/middleware.rs
+++ b/code/crates/test/src/middleware.rs
@@ -3,9 +3,14 @@ use core::fmt;
 use malachitebft_core_consensus::{LocallyProposedValue, ProposedValue};
 use malachitebft_core_types::{CommitCertificate, NilOrVal, Round};
 
+use crate::decided_value::DecidedValue;
 use crate::{Address, Genesis, Height, Proposal, TestContext, ValidatorSet, Value, ValueId, Vote};
 
 pub trait Middleware: fmt::Debug + Send + Sync {
+    fn get_decided_value(&self, _height: Height) -> Option<DecidedValue> {
+        None
+    }
+
     fn get_validator_set(
         &self,
         _ctx: &TestContext,


### PR DESCRIPTION
Closes: #4, #14

**Problem**
This PR solves 2 big value-sync issues:
1. If a `SyncedValueResponse` gets popped from the **bounded** input queue, then the syncing node blocks forever. This stems among others from the following:
- Both the [sync](https://github.com/informalsystems/malachite/blob/main/code/crates/engine/src/sync.rs#L470) and the [consensus](https://github.com/informalsystems/malachite/blob/main/code/crates/engine/src/consensus.rs#L1333) actor subscribe to gossip's `NetworkEvent`s. So, when a node receives a sync response, both the sync and the consensus actor receive the response and act on it in **parallel**. Because the `consensus` actor does not perform sanity checks on the received responses (e.g., that the response stems from a peer from which we actually requested values), it can be the case that a malicious validator keeps sending bogus sync responses to a peer and as a result the **bounded** [`input_queue`](https://github.com/informalsystems/malachite/blob/d3ef5907498cb4a8ee14007c05d91565d9202f77/code/crates/core-consensus/src/state.rs#L28) gets filled and it starts popping `SyncValueResponse`s. If a single `SyncValueResponse` the syncing node blocks forever.
- The `input_queue` is used both for `SyncValueResponse`s, votes, etc. so, for example, if a lot of votes are added in the `input_queue`, this could lead to having `SyncValueResponse`s getting popped, leading again to a syncing node blocking.
2.  Value sync makes the implicit assumption that [_“the request will eventually complete successfully”_](https://github.com/informalsystems/malachite/issues/14). However, the `sync_height` variable that is used to track the starting point of requested values only increases. If a response is lost, the missing range can never be re-requested, since `sync_height` won’t move backwards, hence violating the implicit assumption. This issue is compounded by the tight coupling between requests and responses (e.g., an invalid response immediately triggers a new request), which makes recovery from lost or invalid responses difficult.

**Solution**
1. The consensus actor only starts processing sync responses after they have been sanity checked by the sync actor. To do this we introduce the `ProcessSyncResponse` message that is called by the sync actor only after it has sanity checked a response. To do this, the sync actor needs to be able to send a message to the consensus actor. However, the consensus actors needs the sync actor to spawn. To solve this circular dependency we introduce `SetConsensusActor` on the sync actor to be able to set its consensus actor after the `sync` actor has started. Additionally, we introduce a new `sync_input_queue` **bounded** queue specifically for `SyncValueResponse`s to prevent having votes, etc. from popping `SyncValueResponse`s. Finally, we introduce relevant methods (e.g., `current_number_of_heights`) to compute how many heights we have received or are waiting to receive before issuing another request to _prevent_ overflowing `sync_input_queue`.

2. We did an extensive revamp, discarding the implication [_“the request will eventually complete successfully”_](https://github.com/informalsystems/malachite/issues/14). Specifically, we clarify the difference between requests that are inflight (i.e., on the wire for which we haven't received a response) and for requests for which we have received a response but their heights/values are still pending consensus verification. This is done through `inflight_requests` and `pending_consensus_requests`. We get rid of `sync_height` altogether and compute the range we want to request by looking at the `tip_height`, `inflight_requests`, and `pending_consensus_requests`. As a result, when we receive a response, we do no need to re-issue a request, we just need to update `inflight_requests` and `pending_consensus_requests` accordingly. Finally, we remove `random_peer_with_except` because we believe the peer selected should be based solely on the underlying peer scorer.

**Testing**
Introduced a test on what happens when we have invalid values. Also [verified](https://gist.github.com/insumity/8a63eda293c3c6d0cf733cc9271a1497?permalink_comment_id=5783028#gistcomment-5783028) that with the testnet example that a node can indeed sync.


---

### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
